### PR TITLE
Document scope-recall naming convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,21 @@ This replaces the old `lancepro` naming, which was misleading because the earlie
 - **Operator actions fail closed**: cross-scope export/dedupe/govern/repair paths require explicit maintenance mode.
 - **Install remains practical**: hosted embeddings are used when configured, while deterministic `local-hash` keeps no-key bootstrap available.
 
+### Naming convention
+
+The hyphenated and underscored forms have separate, intentional roles:
+
+| Form | Use |
+| --- | --- |
+| `scope-recall` | Public project/provider identity, package display name, plugin and storage directory names, and user-facing wording |
+| `scope_recall` | Python imports and identifiers, Hermes tool names, config keys, and SQL table/index names |
+| `SCOPE_RECALL_*` | Environment variables |
+
+For example, install the plugin under `$HERMES_HOME/plugins/scope-recall/`, select
+it with `memory.provider: scope-recall`, import it as `scope_recall`, and call
+tools such as `scope_recall_store`. These names are compatibility surfaces and
+should not be mechanically renamed to one spelling.
+
 ### Deployment boundaries
 
 `scope-recall` is the local per-Hermes recall layer. In multi-agent deployments that already run a central shared backend such as PostgreSQL, keep that backend as the cross-agent source of truth and connect it to `scope-recall` through explicit import/export/tool boundaries.

--- a/docs/stability.md
+++ b/docs/stability.md
@@ -12,6 +12,19 @@ The stable public provider name is:
 
 The legacy `lancepro` naming exists only as a transition compatibility path. New installs and documentation should use `scope-recall`.
 
+The V1 naming split is intentional:
+
+- use `scope-recall` for the public project identity, `plugin.yaml` and
+  `pyproject.toml` project names, the Hermes `memory.provider` value, unpacked
+  plugin and provider-owned storage directories, and user-facing wording
+- use `scope_recall` where an identifier is required, including Python
+  imports/modules/functions, Hermes tool names, config keys, and SQL
+  table/index names
+- use uppercase `SCOPE_RECALL_*` for environment variables
+
+These existing names are compatibility surfaces. V1 does not mechanically
+rename one form to the other.
+
 ## Stable V1 install shape
 
 The supported Hermes install shape for V1 is an unpacked local plugin directory:


### PR DESCRIPTION
## Summary

- document the intended roles of `scope-recall`, `scope_recall`, and `SCOPE_RECALL_*`
- add the convention to the V1 stability contract
- clarify that existing names are compatibility surfaces and should not be broadly renamed

## Validation

- `git diff --check`
- release metadata check
- source-tree hygiene scan

Closes #4