### PR TITLE
fix(memory): gate low-value digest promotions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to `scope-recall` will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- Reduced the default primary-agent tool schema surface by hiding the low-frequency `scope_recall_store_secret_index` schema behind `secret_index_tools_enabled=true`; direct calls also fail closed unless the operator explicitly enables it.
+
+### Fixed
+- Added a deterministic journal-digest durable-value gate so obvious webhook/notification/log/tool-summary noise is rejected before it can become durable `user`/`memory`/`project`/`ops` rows, while preserving reusable root-cause/fix/workflow candidates.
+
 ## [1.5.2] - 2026-06-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ Minimal default shape:
   "auto_capture": true,
   "enable_tools": true,
   "maintenance_tools_enabled": false,
+  "secret_index_tools_enabled": false,
   "retrieval": {
     "mode": "hybrid",
     "lexical_weight": 0.45,
@@ -382,7 +383,7 @@ Nightly digest uses the same deterministic artifact extraction in addition to it
 
 ### Secret indexes, not plaintext secret storage
 
-`scope_recall_store_secret_index` stores a searchable credential index without putting plaintext secret values into the ordinary recall surface. Store the real password/token/API key/private key in an external vault or keyring, then store only the locator and safe metadata in `scope-recall`.
+`scope_recall_store_secret_index` stores a searchable credential index without putting plaintext secret values into the ordinary recall surface. Store the real password/token/API key/private key in an external vault or keyring, then store only the locator and safe metadata in `scope-recall`. To reduce the default tool schema footprint, this low-frequency tool is hidden and direct calls fail unless `secret_index_tools_enabled=true` is set.
 
 Example tool payload shape:
 
@@ -668,6 +669,7 @@ Primary-agent default tools:
 scope_recall_store
 scope_recall_search
 scope_recall_context
+scope_recall_profile
 scope_recall_probe
 scope_recall_related
 scope_recall_feedback
@@ -679,6 +681,11 @@ scope_recall_stats
 scope_recall_inspect
 scope_recall_explain
 scope_recall_benchmark
+scope_recall_playbook_search
+scope_recall_playbook_inspect
+scope_recall_experience_preflight
+scope_recall_playbook_feedback
+scope_recall_experience_stats
 ```
 
 Release `1.5.2` adds Recall Funnel observability and retrieval-regression benchmarking:
@@ -714,6 +721,17 @@ scope_recall_dedupe
 scope_recall_govern
 scope_recall_hygiene
 scope_recall_repair
+scope_recall_playbook_create
+scope_recall_playbook_review
+scope_recall_experience_promote
+scope_recall_forgetting_report
+scope_recall_forgetting_run
+```
+
+Secret-index tools are also hidden by default and require `secret_index_tools_enabled=true`:
+
+```text
+scope_recall_store_secret_index
 ```
 
 `scope_recall_hygiene` is read-only. It reports runtime-wrapper noise, assistant scratch prose, duplicate dedupe keys, very short/long rows, `general` rows present in the vector companion, likely promotion candidates, and likely delete candidates. It does not delete, merge, promote, or rewrite rows.
@@ -726,7 +744,7 @@ python scripts/report.hygiene.py --db "$HERMES_HOME/scope-recall/memory.sqlite3"
 
 Destructive cleanup is intentionally out-of-band: use the hygiene report first, then require an explicit operator decision before running any separate delete/merge/dedupe action. The shipped hygiene path is dry-run/report-only.
 
-`scope_recall_export` defaults to the current accessible scope set: local scratch scope plus shared durable scope. Passing `scope_only=false` is an operator maintenance action and fails closed unless `maintenance_tools_enabled=true`.
+`scope_recall_export` defaults to the current accessible scope set: local scratch scope plus shared durable scope. Passing `scope_only=false` remains an operator maintenance action and fails closed unless `maintenance_tools_enabled=true`.
 
 Backward-compatible aliases are still accepted internally for old `lancepro_*` tool names during transition.
 

--- a/config.json
+++ b/config.json
@@ -73,6 +73,7 @@
   ],
   "enable_tools": true,
   "maintenance_tools_enabled": false,
+  "secret_index_tools_enabled": false,
   "experience": {
     "enabled": true,
     "prefetch_enabled": true,

--- a/config.py
+++ b/config.py
@@ -69,6 +69,7 @@ DEFAULT_CONFIG: dict[str, Any] = {
     ],
     "enable_tools": True,
     "maintenance_tools_enabled": False,
+    "secret_index_tools_enabled": False,
     "experience": {
         "enabled": True,
         "prefetch_enabled": True,

--- a/journal.py
+++ b/journal.py
@@ -512,6 +512,59 @@ def _looks_like_historical_template_noise(text: str) -> bool:
     return False
 
 
+LOW_VALUE_NOTIFICATION_RE = re.compile(
+    r"\b(?:webhook|web\s+hook|bot\s+(?:push|message|status)|notification|push\s+message|"
+    r"sign[-\s]?in|check[-\s]?in|subscription|subscribed|unsubscribe|qas)\b|"
+    r"(?:通知|推送|机器人消息|签到|签入|登录提醒|订阅(?:更新|通知)?)",
+    re.IGNORECASE,
+)
+LOW_VALUE_LOG_RE = re.compile(
+    r"\b(?:docker\s+logs?|journalctl|kubectl\s+logs?|stack\s+trace|traceback|stderr|stdout|"
+    r"shell\s+(?:prompt|output)|terminal\s+output|command\s+output|tool\s+(?:execution\s+)?summary|tool\s+result)\b|"
+    r"(?:工具执行摘要|工具结果|命令输出|终端输出|日志输出|堆栈|调用栈)",
+    re.IGNORECASE,
+)
+LOW_VALUE_PROGRESS_RE = re.compile(
+    r"\b(?:backup\s+path|temporary\s+file|run\s+result|task\s+progress|no\s+action\s+required|"
+    r"one[-\s]?off|status\s+update)\b|(?:临时文件|备份路径|任务进度|一次性|无需处理|状态更新)",
+    re.IGNORECASE,
+)
+HIGH_VALUE_DURABLE_SIGNAL_RE = re.compile(
+    r"\b(?:preference|prefers|constraint|policy|api\s+boundary|environment\s+fact|root\s+cause|"
+    r"fix|workaround|verification|verified|reusable|workflow|procedure|runbook|pitfall|"
+    r"design\s+decision|stable|must|should|requires?|rollback|guardrail)\b|"
+    r"(?:偏好|约束|边界|环境事实|根因|修复|验证|可复用|流程|步骤|规程|坑|设计决策|稳定|必须|应该|回滚|防护)",
+    re.IGNORECASE,
+)
+
+
+def _has_high_value_durable_signal(text: str) -> bool:
+    return bool(HIGH_VALUE_DURABLE_SIGNAL_RE.search(text or ""))
+
+
+def _low_value_promotion_reason(candidate: JournalDigestCandidate) -> str:
+    """Return a rejection reason for obvious journal-digest promotion noise.
+
+    Capture filters protect raw journal ingestion, but an LLM digest can rephrase
+    webhook/log/tool noise into a plausible durable fact.  This second gate is
+    intentionally conservative: only obvious notification/log/progress shapes are
+    blocked, and root-cause/fix/workflow/preference/constraint signals still pass.
+    """
+    text = clean_text(candidate.content)
+    if not text:
+        return "low-value-empty"
+    has_value_signal = _has_high_value_durable_signal(text)
+    if candidate.memory_type == "tool_trace" and not has_value_signal:
+        return "low-value-tool-trace"
+    if LOW_VALUE_NOTIFICATION_RE.search(text) and not has_value_signal:
+        return "low-value-notification"
+    if LOW_VALUE_LOG_RE.search(text) and not has_value_signal:
+        return "low-value-log-or-tool-summary"
+    if LOW_VALUE_PROGRESS_RE.search(text) and not has_value_signal:
+        return "low-value-progress"
+    return ""
+
+
 def _digest_role_summary(entries: list[JournalEntry], role: str, *, limit: int) -> str:
     chunks = [
         entry.content.strip()
@@ -760,17 +813,27 @@ def _merge_metadata(conn: sqlite3.Connection, *, memory_id: str, candidate: Jour
     sync_memory_entities(conn, memory_id=memory_id, content=str(row["content"]), target=str(row["target"]), metadata=existing)
 
 
-def _candidate_allowed(candidate: JournalDigestCandidate) -> bool:
+def _candidate_rejection_reason(candidate: JournalDigestCandidate) -> str:
     if candidate.target not in JOURNAL_TARGETS:
-        return False
+        return "invalid-target"
     if len(candidate.content) < 40:
-        return False
+        return "too-short"
     if _looks_like_historical_template_noise(candidate.content):
-        return False
+        return "historical-template-noise"
     lowered = candidate.content.lower()
     if "operations workflow summary from journal digest:" in lowered or "journal digest memory" in lowered:
-        return False
-    return should_capture_text(candidate.content).allowed
+        return "historical-template-noise"
+    capture_result = should_capture_text(candidate.content)
+    if not capture_result.allowed:
+        return f"capture-filter:{capture_result.reason or 'blocked'}"
+    low_value_reason = _low_value_promotion_reason(candidate)
+    if low_value_reason:
+        return low_value_reason
+    return ""
+
+
+def _candidate_allowed(candidate: JournalDigestCandidate) -> bool:
+    return not _candidate_rejection_reason(candidate)
 
 
 def _cross_platform_metadata(scope: RuntimeScope, config: dict[str, Any] | None = None) -> dict[str, Any]:
@@ -800,12 +863,13 @@ def apply_journal_candidates(
     actions: list[dict[str, Any]] = []
     processed_entry_ids: set[int] = set()
     for candidate in candidates:
-        if not _candidate_allowed(candidate):
+        rejection_reason = _candidate_rejection_reason(candidate)
+        if rejection_reason:
             counts["skipped"] += 1
-            actions.append({"action": "skip", "reason": "candidate filtered", "entry_ids": candidate.entry_ids})
+            actions.append({"action": "skip", "reason": rejection_reason, "entry_ids": candidate.entry_ids})
             processed_entry_ids.update(int(entry_id) for entry_id in candidate.entry_ids)
             if not dry_run:
-                _record_journal_rejection(conn, run_id=run_id, entry_ids=candidate.entry_ids, reason="candidate filtered", candidate=candidate)
+                _record_journal_rejection(conn, run_id=run_id, entry_ids=candidate.entry_ids, reason=rejection_reason, candidate=candidate)
                 conn.commit()
             continue
         match_id, match_content, score = _find_match(conn, scope_ids, candidate)

--- a/provider.py
+++ b/provider.py
@@ -874,7 +874,6 @@ class ScopeRecallMemoryProvider(MemoryProvider):
             return []
         schemas = [
             SCOPE_RECALL_STORE_SCHEMA,
-            SCOPE_RECALL_STORE_SECRET_INDEX_SCHEMA,
             SCOPE_RECALL_SEARCH_SCHEMA,
             SCOPE_RECALL_CONTEXT_SCHEMA,
             SCOPE_RECALL_PROFILE_SCHEMA,
@@ -884,12 +883,14 @@ class ScopeRecallMemoryProvider(MemoryProvider):
             SCOPE_RECALL_FORGET_SCHEMA,
             SCOPE_RECALL_UPDATE_SCHEMA,
             SCOPE_RECALL_MERGE_SCHEMA,
-            SCOPE_RECALL_EXPORT_SCHEMA,
-            SCOPE_RECALL_STATS_SCHEMA,
             SCOPE_RECALL_INSPECT_SCHEMA,
             SCOPE_RECALL_EXPLAIN_SCHEMA,
+            SCOPE_RECALL_EXPORT_SCHEMA,
+            SCOPE_RECALL_STATS_SCHEMA,
             SCOPE_RECALL_BENCHMARK_SCHEMA,
         ]
+        if config_bool(config, "secret_index_tools_enabled", False):
+            schemas.append(SCOPE_RECALL_STORE_SECRET_INDEX_SCHEMA)
         raw_experience_config = config.get("experience")
         experience_config: dict[str, Any] = dict(raw_experience_config) if isinstance(raw_experience_config, dict) else {}
         experience_enabled = config_bool(experience_config, "enabled", True)

--- a/tests/test_journal_digest.py
+++ b/tests/test_journal_digest.py
@@ -175,6 +175,96 @@ def test_skipped_journal_candidates_still_advance_watermark(tmp_path):
     assert rejection_ids == {existing_entry_id, filtered_entry_id}
 
 
+def test_journal_digest_rejects_low_value_notification_log_and_tool_summary_candidates(tmp_path):
+    conn = _open_memory_db(tmp_path / "memory.sqlite3")
+    scope = _scope()
+    scope_id = build_scope_id(scope)
+    shared_scope_id = build_shared_scope_id(scope)
+    entry_ids = [
+        append_journal_entry(
+            conn,
+            scope=scope,
+            scope_id=scope_id,
+            shared_scope_id=shared_scope_id,
+            session_id="noise-digest",
+            turn_number=index,
+            role="user",
+            content=content,
+        )
+        for index, content in enumerate(
+            [
+                "QAS webhook notification: subscription update delivered successfully; no action required.",
+                "docker logs output showed transient INFO heartbeat lines and stdout noise only.",
+                "Tool execution summary: ran terminal, read_file, gh issue list, and printed task progress.",
+            ],
+            start=1,
+        )
+    ]
+    candidates = [
+        JournalDigestCandidate(
+            content="QAS webhook notification reported a subscription update and successful bot push delivery; no action required.",
+            target="ops",
+            memory_type="summary",
+            entry_ids=[entry_ids[0]],
+        ),
+        JournalDigestCandidate(
+            content="docker logs output consisted of transient INFO heartbeat lines, stdout noise, and pasted terminal output.",
+            target="ops",
+            memory_type="summary",
+            entry_ids=[entry_ids[1]],
+        ),
+        JournalDigestCandidate(
+            content="Tool execution summary: terminal/read_file/git commands were used and the task progress was printed.",
+            target="memory",
+            memory_type="tool_trace",
+            entry_ids=[entry_ids[2]],
+        ),
+    ]
+
+    result = apply_journal_candidates(conn, None, scope, run_id="low-value-gate", candidates=candidates)
+
+    assert result["counts"]["skipped"] == 3
+    assert set(result["processed_entry_ids"]) == set(entry_ids)
+    assert conn.execute("SELECT COUNT(*) FROM memories").fetchone()[0] == 0
+    reasons = {row["reason"] for row in conn.execute("SELECT reason FROM journal_rejections").fetchall()}
+    assert "low-value-notification" in reasons
+    assert "low-value-log-or-tool-summary" in reasons
+    assert "low-value-tool-trace" in reasons
+
+
+def test_journal_digest_allows_reusable_root_cause_fix_workflow_candidate(tmp_path):
+    conn = _open_memory_db(tmp_path / "memory.sqlite3")
+    scope = _scope()
+    entry_id = append_journal_entry(
+        conn,
+        scope=scope,
+        scope_id=build_scope_id(scope),
+        shared_scope_id=build_shared_scope_id(scope),
+        session_id="valuable-digest",
+        turn_number=1,
+        role="user",
+        content="把 journalctl 日志里 database locked 的根因和修复流程记下来，后续排障要复用。",
+    )
+    candidate = JournalDigestCandidate(
+        content=(
+            "Reusable ops workflow: when journalctl or docker logs show SQLite database locked, root cause is usually a live "
+            "service holding the WAL; fix by identifying the holder with fuser, scheduling a safe restart window, then rerun doctor verification."
+        ),
+        target="ops",
+        memory_type="workflow",
+        entry_ids=[entry_id],
+    )
+
+    result = apply_journal_candidates(conn, None, scope, run_id="valuable-gate", candidates=[candidate])
+
+    assert result["counts"]["inserted"] == 1
+    assert result["processed_entry_ids"] == [entry_id]
+    row = conn.execute("SELECT target, content FROM memories").fetchone()
+    assert row["target"] == "ops"
+    assert "root cause" in row["content"]
+    assert conn.execute("SELECT COUNT(*) FROM journal_rejections").fetchone()[0] == 0
+
+
 def test_feedback_and_governance_previews_redact_secret_like_text(tmp_path):
     conn = _open_memory_db(tmp_path / "memory.sqlite3")
     scope = _scope()
@@ -602,7 +692,7 @@ def test_journal_digest_records_rejections_and_advances_watermark_for_filtered_c
     assert result["processed_entry_ids"] == [123]
     row = conn.execute("SELECT reason, candidate FROM journal_rejections WHERE journal_entry_id = 123").fetchone()
     assert row is not None
-    assert row["reason"] == "candidate filtered"
+    assert row["reason"] == "invalid-target"
 
 
 def test_journal_duplicate_store_row_links_evidence_without_rejection(tmp_path, monkeypatch):

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -1449,7 +1449,7 @@ def test_maintenance_tool_schemas_require_operator_config(provider):
     schemas = provider.get_tool_schemas()
     names = {schema["name"] for schema in schemas}
     assert {"scope_recall_context", "scope_recall_probe", "scope_recall_related", "scope_recall_feedback"} <= names
-    assert "scope_recall_store_secret_index" in names
+    assert "scope_recall_store_secret_index" not in names
     assert "scope_recall_dedupe" not in names
     assert "scope_recall_govern" not in names
     assert "scope_recall_repair" not in names
@@ -1464,6 +1464,10 @@ def test_maintenance_tool_schemas_require_operator_config(provider):
     assert "scope_recall_dedupe" in operator_names
     assert "scope_recall_govern" in operator_names
     assert "scope_recall_repair" in operator_names
+
+    provider._config["secret_index_tools_enabled"] = True
+    secret_names = {schema["name"] for schema in provider.get_tool_schemas()}
+    assert "scope_recall_store_secret_index" in secret_names
 
 
 def test_tool_store_enriches_external_artifact_anchors(provider):
@@ -1495,6 +1499,7 @@ def test_tool_store_enriches_external_artifact_anchors(provider):
 
 
 def test_secret_index_tool_stores_vault_ref_without_plaintext_secret(provider):
+    provider._config["secret_index_tools_enabled"] = True
     secret_value = "correct-horse-battery-staple-12345"
     payload = json.loads(
         provider.handle_tool_call(
@@ -1530,6 +1535,7 @@ def test_secret_index_tool_stores_vault_ref_without_plaintext_secret(provider):
 
 
 def test_secret_index_allows_credential_label_with_api_key_kind(provider):
+    provider._config["secret_index_tools_enabled"] = True
     secret_value = "scope-recall-smoke-secret-should-not-persist-12345"
     payload = json.loads(
         provider.handle_tool_call(

--- a/tests/test_tool_hygiene.py
+++ b/tests/test_tool_hygiene.py
@@ -29,6 +29,68 @@ def _store(provider, content: str, target: str = "memory") -> dict:
     return json.loads(provider.handle_tool_call("scope_recall_store", {"content": content, "target": target}))
 
 
+def _schema_names(provider) -> set[str]:
+    return {str(schema["name"]) for schema in provider.get_tool_schemas()}
+
+
+def _provider_with_config(tmp_path, config: dict):
+    config_path = tmp_path / "scope-recall" / "config.json"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+    plugin = load_memory_provider("scope-recall")
+    assert plugin is not None
+    plugin.initialize(
+        "session-configured",
+        hermes_home=str(tmp_path),
+        platform="telegram",
+        agent_context="primary",
+        agent_identity="yuheng",
+        agent_workspace="hermes",
+        user_id="joy",
+        chat_id="group-a",
+    )
+    return plugin
+
+
+def test_default_schema_surface_hides_low_frequency_secret_index_tool(provider):
+    names = _schema_names(provider)
+
+    assert "scope_recall_store" in names
+    assert "scope_recall_search" in names
+    assert "scope_recall_profile" in names
+    assert "scope_recall_experience_preflight" in names
+    assert "scope_recall_store_secret_index" not in names
+    assert "scope_recall_export" in names
+    assert "scope_recall_stats" in names
+    assert "scope_recall_benchmark" in names
+    assert "scope_recall_experience_stats" in names
+    assert len(names) <= 21
+
+    assert "secret_index_tools_enabled=true" in provider.handle_tool_call("scope_recall_store_secret_index", {"label": "test"})
+
+
+def test_secret_index_schema_surface_is_explicit_opt_in(tmp_path):
+    plugin = _provider_with_config(
+        tmp_path,
+        {
+            "secret_index_tools_enabled": True,
+            "vector": {"enabled": False},
+        },
+    )
+    try:
+        names = _schema_names(plugin)
+
+        assert "scope_recall_store_secret_index" in names
+        assert "scope_recall_export" in names
+        assert "scope_recall_stats" in names
+        assert "scope_recall_benchmark" in names
+        assert "scope_recall_experience_stats" in names
+        assert "scope_recall_govern" not in names
+        assert "scope_recall_forgetting_run" not in names
+    finally:
+        plugin.shutdown()
+
+
 def test_tool_store_uses_capture_filter_for_secret_like_content(provider):
     payload = _store(provider, "api_key = public-test-token should not become memory", "memory")
 

--- a/tooling.py
+++ b/tooling.py
@@ -196,6 +196,8 @@ class ScopeRecallToolService:
         )
 
     def _handle_store_secret_index(self, args: dict[str, Any]) -> str:
+        if not config_bool(self.provider._config, "secret_index_tools_enabled", False):
+            return tool_error("scope_recall_store_secret_index requires secret_index_tools_enabled=true")
         content, metadata = build_secret_index(args)
         target = str(args.get("target") or "ops").strip().lower()
         if target not in {"memory", "project", "ops"}:


### PR DESCRIPTION
## Summary

Fixes two follow-up issues from the open issue sweep:

- Adds a deterministic journal-digest durable-value gate so obvious webhook/notification/log/tool-summary noise is rejected before promotion into durable memory.
- Reduces the default tool schema surface by hiding the low-frequency secret-index tool unless `secret_index_tools_enabled=true` is explicitly configured.
- Keeps existing read-only diagnostic tools (`stats`, `benchmark`, `export`) compatible by default; only operator mutation/maintenance tools remain behind `maintenance_tools_enabled=true`.

## Issue coverage

- Addresses #17 by adding explicit rejection reasons (`low-value-notification`, `low-value-log-or-tool-summary`, `low-value-tool-trace`, etc.) and regression tests that retain root-cause/fix/workflow candidates.
- Partially addresses #18 with a low-risk schema reduction for the largest/lowest-frequency secret-index schema while preserving existing diagnostics. Further dynamic tool batching can be handled in a separate larger design PR.
- Confirms #13 already has session_messages dump defenses covered by existing tests; this PR keeps those guardrails green while changing adjacent tool schema behavior.

## Verification

- `python3 -m py_compile journal.py provider.py tooling.py config.py tests/test_journal_digest.py tests/test_tool_hygiene.py tests/test_provider.py`
- `ruff check`
- `pyright`
- `python3 -m pytest -q` → `446 passed, 1 skipped`
- `python3 scripts/check.release.py` → `ok: true`
