### PR TITLE
fix(tools): add compact schema profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ All notable changes to `scope-recall` will be documented in this file.
 ## [Unreleased]
 
 ### Changed
-- Reduced the default primary-agent tool schema surface by hiding the low-frequency `scope_recall_store_secret_index` schema behind `secret_index_tools_enabled=true`; direct calls also fail closed unless the operator explicitly enables it.
+- Reduced the default primary-agent tool schema surface with a new `tool_schema_profile="compact"` default (6 tools, about 4.7 KB in repo-local measurement) that exposes core store/search/context/profile plus compact `scope_recall_memory` and `scope_recall_entity` dispatch tools; `tool_schema_profile="standard"` restores the legacy 20-tool read-only/diagnostic surface, and `tool_schema_extra_tools` can selectively expose diagnostics while staying compact.
+- Kept the low-frequency `scope_recall_store_secret_index` schema behind `secret_index_tools_enabled=true`; direct calls also fail closed unless the operator explicitly enables it.
 
 ### Fixed
 - Added a deterministic journal-digest durable-value gate so obvious webhook/notification/log/tool-summary noise is rejected before it can become durable `user`/`memory`/`project`/`ops` rows, while preserving reusable root-cause/fix/workflow candidates.

--- a/README.md
+++ b/README.md
@@ -249,6 +249,8 @@ Minimal default shape:
   "auto_recall": true,
   "auto_capture": true,
   "enable_tools": true,
+  "tool_schema_profile": "compact",
+  "tool_schema_extra_tools": [],
   "maintenance_tools_enabled": false,
   "secret_index_tools_enabled": false,
   "retrieval": {
@@ -663,30 +665,44 @@ This is a local deterministic governance layer, not a remote LLM extraction pipe
 
 ## Provider tools
 
-Primary-agent default tools:
+Primary-agent default tools use `tool_schema_profile: "compact"` to keep the base request small:
 
 ```text
 scope_recall_store
 scope_recall_search
 scope_recall_context
 scope_recall_profile
-scope_recall_probe
-scope_recall_related
-scope_recall_feedback
-scope_recall_forget
-scope_recall_update
-scope_recall_merge
-scope_recall_export
-scope_recall_stats
-scope_recall_inspect
-scope_recall_explain
-scope_recall_benchmark
-scope_recall_playbook_search
-scope_recall_playbook_inspect
-scope_recall_experience_preflight
-scope_recall_playbook_feedback
-scope_recall_experience_stats
+scope_recall_memory
+scope_recall_entity
 ```
+
+The compact profile replaces several overlapping schemas with two dispatch tools:
+
+- `scope_recall_memory(action=...)` covers `inspect`, `feedback`, `update`, `merge`, and `forget` by exact id.
+- `scope_recall_entity(action=...)` covers `probe` and `related` entity graph reads.
+
+Legacy individual tools remain direct-call compatible. To expose the pre-compact schema surface, set:
+
+```json
+{
+  "tool_schema_profile": "standard"
+}
+```
+
+To keep compact mode but expose selected diagnostics, use `tool_schema_extra_tools`:
+
+```json
+{
+  "tool_schema_profile": "compact",
+  "tool_schema_extra_tools": ["scope_recall_stats", "scope_recall_benchmark"]
+}
+```
+
+Schema-surface targets after the compact-profile change:
+
+- default compact: 6 tools, about 4.7 KB of JSON schema in repo-local measurement
+- standard profile: 20 tools, about 10.6 KB
+- maintenance/secret schema surfaces still require their explicit safety flags
 
 Release `1.5.2` adds Recall Funnel observability and retrieval-regression benchmarking:
 
@@ -746,6 +762,8 @@ Destructive cleanup is intentionally out-of-band: use the hygiene report first, 
 
 `scope_recall_export` defaults to the current accessible scope set: local scratch scope plus shared durable scope. Passing `scope_only=false` remains an operator maintenance action and fails closed unless `maintenance_tools_enabled=true`.
 
+`scope_recall_stats`, `scope_recall_export`, `scope_recall_explain`, `scope_recall_benchmark`, and Experience Kernel tools still work through direct tool calls, but are no longer part of the compact default schema unless `tool_schema_profile="standard"` or `tool_schema_extra_tools` exposes them.
+
 Backward-compatible aliases are still accepted internally for old `lancepro_*` tool names during transition.
 
 ### Tool quick reference
@@ -765,8 +783,11 @@ results = scope_recall_search(
     limit=3,
 )
 
-# Inspect truth/vector health.
-stats = scope_recall_stats()
+# Inspect/update by exact id through the compact memory dispatcher.
+inspected = scope_recall_memory(action="inspect", id=store["id"])
+
+# Probe entity memory through the compact entity dispatcher.
+entity = scope_recall_entity(action="probe", entity="this project", limit=3)
 ```
 
 Example `scope_recall_stats` shape:
@@ -799,23 +820,26 @@ Example `scope_recall_stats` shape:
 
 | Tool | Purpose |
 | --- | --- |
-| `scope_recall_store` | Store a provider-owned memory row after deterministic governance checks |
-| `scope_recall_search` | Search the current local scratch scope plus shared durable scope with lexical/vector/hybrid retrieval; pass `include_trace=true` to inspect the Recall Funnel |
-| `scope_recall_context` | Render a compact task-relevant memory context block plus structured evidence for a query |
-| `scope_recall_probe` | Inspect accessible memories attached to a specific entity |
-| `scope_recall_related` | List entities that co-occur with a given entity in accessible memories |
-| `scope_recall_feedback` | Mark a memory as helpful or unhelpful so trust scoring can adjust future recall |
-| `scope_recall_forget` | Delete memories by exact id/ids within the current accessible scope set; search or inspect first, then pass explicit ids |
-| `scope_recall_update` | Replace content/category within the current accessible scope set; shared/local target-mode changes are rejected |
+| `scope_recall_store` | Compact default: store a provider-owned memory row after deterministic governance checks |
+| `scope_recall_search` | Compact default: search local scratch plus shared durable scope; pass `include_trace=true` for Recall Funnel evidence |
+| `scope_recall_context` | Compact default: render a task-relevant memory context block plus structured evidence |
+| `scope_recall_profile` | Compact default: render a bounded high-level profile/context surface |
+| `scope_recall_memory` | Compact default: dispatch exact-id `inspect`, `feedback`, `update`, `merge`, and `forget` operations |
+| `scope_recall_entity` | Compact default: dispatch entity `probe` and `related` reads |
+| `scope_recall_probe` | Standard profile/direct-call: inspect accessible memories attached to a specific entity |
+| `scope_recall_related` | Standard profile/direct-call: list entities that co-occur with a given entity |
+| `scope_recall_feedback` | Standard profile/direct-call: mark a memory helpful/unhelpful for trust scoring |
+| `scope_recall_forget` | Standard profile/direct-call: delete memories by exact id/ids within the current accessible scope set |
+| `scope_recall_update` | Standard profile/direct-call: replace content/category within the current accessible scope set |
+| `scope_recall_merge` | Standard profile/direct-call: merge same-scope memories into a target row |
+| `scope_recall_export` | Standard profile/direct-call: export SQLite truth rows as JSON/JSONL; `scope_only=false` is maintenance-gated |
+| `scope_recall_explain` | Standard profile/direct-call: explain rank-aligned retrieval evidence and Recall Funnel trace |
+| `scope_recall_benchmark` | Standard profile/direct-call: run latency/assertion/quality-regression checks |
+| `scope_recall_stats` | Standard profile/direct-call: inspect storage, retrieval, scope, and vector health |
 | `scope_recall_dedupe` | Operator-only: inspect or collapse exact duplicate rows |
-| `scope_recall_merge` | Merge same-scope memories into a target row; shared/local mixing is rejected |
-| `scope_recall_export` | Export SQLite truth rows as JSON or JSONL; defaults to current accessible scope set |
 | `scope_recall_govern` | Operator-only: review tier distribution and decay/archive candidates |
 | `scope_recall_hygiene` | Operator-only, read-only: report memory-quality cleanup/promotion candidates without modifying rows |
 | `scope_recall_repair` | Operator-only: repair/rebuild the configured vector companion from SQLite truth |
-| `scope_recall_explain` | Explain rank-aligned retrieval evidence and include the latest Recall Funnel trace |
-| `scope_recall_benchmark` | Run latency, assertion, Recall Funnel, and quality-regression checks with aggregate metrics |
-| `scope_recall_stats` | Inspect storage, retrieval, scope, and vector health |
 
 ---
 

--- a/config.json
+++ b/config.json
@@ -72,6 +72,8 @@
     "<available_skills>[\\s\\S]*?</available_skills>"
   ],
   "enable_tools": true,
+  "tool_schema_profile": "compact",
+  "tool_schema_extra_tools": [],
   "maintenance_tools_enabled": false,
   "secret_index_tools_enabled": false,
   "experience": {

--- a/config.py
+++ b/config.py
@@ -68,6 +68,8 @@ DEFAULT_CONFIG: dict[str, Any] = {
         r"<available_skills>[\s\S]*?</available_skills>",
     ],
     "enable_tools": True,
+    "tool_schema_profile": "compact",
+    "tool_schema_extra_tools": [],
     "maintenance_tools_enabled": False,
     "secret_index_tools_enabled": False,
     "experience": {

--- a/docs/stability.md
+++ b/docs/stability.md
@@ -77,13 +77,15 @@ V1 keeps these behavior boundaries stable:
 
 ## Stable V1 tool surface
 
-The following tool names are stable for V1:
+The following tool names are stable for V1. `tool_schema_profile="compact"` exposes only the compact default subset in ordinary prompts, while legacy individual tools remain direct-call compatible and can be re-exposed with `tool_schema_profile="standard"` or `tool_schema_extra_tools`.
 
 - `scope_recall_store`
 - `scope_recall_store_secret_index`
 - `scope_recall_search`
 - `scope_recall_context`
 - `scope_recall_profile`
+- `scope_recall_memory`
+- `scope_recall_entity`
 - `scope_recall_probe`
 - `scope_recall_related`
 - `scope_recall_feedback`

--- a/provider.py
+++ b/provider.py
@@ -49,6 +49,7 @@ from .schemas import (
     SCOPE_RECALL_DEDUPE_SCHEMA,
     SCOPE_RECALL_BENCHMARK_SCHEMA,
     SCOPE_RECALL_CONTEXT_SCHEMA,
+    SCOPE_RECALL_ENTITY_SCHEMA,
     SCOPE_RECALL_EXPERIENCE_PREFLIGHT_SCHEMA,
     SCOPE_RECALL_EXPERIENCE_PROMOTE_SCHEMA,
     SCOPE_RECALL_EXPERIENCE_STATS_SCHEMA,
@@ -62,6 +63,7 @@ from .schemas import (
     SCOPE_RECALL_GOVERN_SCHEMA,
     SCOPE_RECALL_HYGIENE_SCHEMA,
     SCOPE_RECALL_INSPECT_SCHEMA,
+    SCOPE_RECALL_MEMORY_SCHEMA,
     SCOPE_RECALL_MERGE_SCHEMA,
     SCOPE_RECALL_PLAYBOOK_CREATE_SCHEMA,
     SCOPE_RECALL_PLAYBOOK_FEEDBACK_SCHEMA,
@@ -872,7 +874,27 @@ class ScopeRecallMemoryProvider(MemoryProvider):
             return []
         if self._scope.agent_context != "primary":
             return []
-        schemas = [
+
+        raw_experience_config = config.get("experience")
+        experience_config: dict[str, Any] = dict(raw_experience_config) if isinstance(raw_experience_config, dict) else {}
+        experience_enabled = config_bool(experience_config, "enabled", True)
+        maintenance_enabled = config_bool(config, "maintenance_tools_enabled", False)
+        secret_index_enabled = config_bool(config, "secret_index_tools_enabled", False)
+        profile = str(config.get("tool_schema_profile") or "compact").strip().lower().replace("-", "_")
+        if profile in {"legacy", "compat", "standard"}:
+            profile = "standard"
+        elif profile not in {"compact", "standard"}:
+            profile = "compact"
+
+        compact_schemas = [
+            SCOPE_RECALL_STORE_SCHEMA,
+            SCOPE_RECALL_SEARCH_SCHEMA,
+            SCOPE_RECALL_CONTEXT_SCHEMA,
+            SCOPE_RECALL_PROFILE_SCHEMA,
+            SCOPE_RECALL_MEMORY_SCHEMA,
+            SCOPE_RECALL_ENTITY_SCHEMA,
+        ]
+        standard_schemas = [
             SCOPE_RECALL_STORE_SCHEMA,
             SCOPE_RECALL_SEARCH_SCHEMA,
             SCOPE_RECALL_CONTEXT_SCHEMA,
@@ -889,35 +911,54 @@ class ScopeRecallMemoryProvider(MemoryProvider):
             SCOPE_RECALL_STATS_SCHEMA,
             SCOPE_RECALL_BENCHMARK_SCHEMA,
         ]
-        if config_bool(config, "secret_index_tools_enabled", False):
-            schemas.append(SCOPE_RECALL_STORE_SECRET_INDEX_SCHEMA)
-        raw_experience_config = config.get("experience")
-        experience_config: dict[str, Any] = dict(raw_experience_config) if isinstance(raw_experience_config, dict) else {}
-        experience_enabled = config_bool(experience_config, "enabled", True)
+        schemas = list(standard_schemas if profile == "standard" else compact_schemas)
+
+        schema_by_name = {str(schema["name"]): schema for schema in [*compact_schemas, *standard_schemas]}
+        if secret_index_enabled:
+            schema_by_name[SCOPE_RECALL_STORE_SECRET_INDEX_SCHEMA["name"]] = SCOPE_RECALL_STORE_SECRET_INDEX_SCHEMA
+        experience_schemas = [
+            SCOPE_RECALL_PLAYBOOK_SEARCH_SCHEMA,
+            SCOPE_RECALL_PLAYBOOK_INSPECT_SCHEMA,
+            SCOPE_RECALL_EXPERIENCE_PREFLIGHT_SCHEMA,
+            SCOPE_RECALL_PLAYBOOK_FEEDBACK_SCHEMA,
+            SCOPE_RECALL_EXPERIENCE_STATS_SCHEMA,
+        ]
         if experience_enabled:
-            schemas.extend(
-                [
-                    SCOPE_RECALL_PLAYBOOK_SEARCH_SCHEMA,
-                    SCOPE_RECALL_PLAYBOOK_INSPECT_SCHEMA,
-                    SCOPE_RECALL_EXPERIENCE_PREFLIGHT_SCHEMA,
-                    SCOPE_RECALL_PLAYBOOK_FEEDBACK_SCHEMA,
-                    SCOPE_RECALL_EXPERIENCE_STATS_SCHEMA,
-                ]
-            )
-        if experience_enabled and config_bool(config, "maintenance_tools_enabled", False):
-            schemas.extend(
-                [
-                    SCOPE_RECALL_DEDUPE_SCHEMA,
-                    SCOPE_RECALL_GOVERN_SCHEMA,
-                    SCOPE_RECALL_REPAIR_SCHEMA,
-                    SCOPE_RECALL_HYGIENE_SCHEMA,
-                    SCOPE_RECALL_PLAYBOOK_CREATE_SCHEMA,
-                    SCOPE_RECALL_PLAYBOOK_REVIEW_SCHEMA,
-                    SCOPE_RECALL_EXPERIENCE_PROMOTE_SCHEMA,
-                    SCOPE_RECALL_FORGETTING_REPORT_SCHEMA,
-                    SCOPE_RECALL_FORGETTING_RUN_SCHEMA,
-                ]
-            )
+            schema_by_name.update({str(schema["name"]): schema for schema in experience_schemas})
+            if profile == "standard":
+                schemas.extend(experience_schemas)
+        maintenance_schemas = [
+            SCOPE_RECALL_DEDUPE_SCHEMA,
+            SCOPE_RECALL_GOVERN_SCHEMA,
+            SCOPE_RECALL_REPAIR_SCHEMA,
+            SCOPE_RECALL_HYGIENE_SCHEMA,
+            SCOPE_RECALL_PLAYBOOK_CREATE_SCHEMA,
+            SCOPE_RECALL_PLAYBOOK_REVIEW_SCHEMA,
+            SCOPE_RECALL_EXPERIENCE_PROMOTE_SCHEMA,
+            SCOPE_RECALL_FORGETTING_REPORT_SCHEMA,
+            SCOPE_RECALL_FORGETTING_RUN_SCHEMA,
+        ]
+        if experience_enabled and maintenance_enabled:
+            schema_by_name.update({str(schema["name"]): schema for schema in maintenance_schemas})
+            schemas.extend(maintenance_schemas)
+
+        if secret_index_enabled:
+            schemas.append(SCOPE_RECALL_STORE_SECRET_INDEX_SCHEMA)
+
+        extra_tools = config.get("tool_schema_extra_tools") or []
+        if isinstance(extra_tools, str):
+            extra_names = [item.strip() for item in extra_tools.split(",")]
+        elif isinstance(extra_tools, list):
+            extra_names = [str(item).strip() for item in extra_tools]
+        else:
+            extra_names = []
+        seen = {str(schema["name"]) for schema in schemas}
+        for name in extra_names:
+            schema = schema_by_name.get(name)
+            if schema is None or name in seen:
+                continue
+            schemas.append(schema)
+            seen.add(name)
         return schemas
 
     def handle_tool_call(self, tool_name: str, args: Dict[str, Any], **kwargs) -> str:

--- a/schemas.py
+++ b/schemas.py
@@ -1,23 +1,23 @@
 SCOPE_RECALL_STORE_SCHEMA = {
     "name": "scope_recall_store",
-    "description": "Store a Scope Recall memory. user/memory/project/ops targets are durable shared memories; general is local scratch.",
+    "description": "Store a Scope Recall memory; durable targets are user/memory/project/ops, general is local scratch.",
     "parameters": {
         "type": "object",
         "properties": {
-            "content": {"type": "string", "description": "Memory text to store."},
+            "content": {"type": "string", "description": "Memory text."},
             "target": {
                 "type": "string",
-                "description": "Category. user/memory/project/ops are shared durable; general stays local to the current chat/thread/session.",
+                "description": "Category; general stays local.",
                 "enum": ["user", "memory", "project", "ops", "general"],
             },
             "scope_mode": {
                 "type": "string",
-                "description": "Optional write scope override. Use shared_pool only when shared_pool.write_enabled is explicitly enabled.",
+                "description": "Optional write scope override.",
                 "enum": ["shared", "local", "shared_pool"],
             },
             "memory_type": {
                 "type": "string",
-                "description": "Optional semantic type used for governance and ranking.",
+                "description": "Semantic type for governance/ranking.",
                 "enum": [
                     "factual",
                     "preference",
@@ -35,17 +35,17 @@ SCOPE_RECALL_STORE_SCHEMA = {
             },
             "importance": {
                 "type": "number",
-                "description": "Optional 0..1 importance hint. Higher values are mildly favored in recall.",
+                "description": "Optional 0..1 importance hint.",
             },
             "entities": {
                 "type": "array",
                 "items": {"type": "string"},
-                "description": "Optional named entities to attach to this memory.",
+                "description": "Named entities.",
             },
             "tags": {
                 "type": "array",
                 "items": {"type": "string"},
-                "description": "Optional tags for filtering and audit.",
+                "description": "Tags for filtering/audit.",
             },
         },
         "required": ["content"],
@@ -88,15 +88,50 @@ SCOPE_RECALL_STORE_SECRET_INDEX_SCHEMA = {
 
 SCOPE_RECALL_SEARCH_SCHEMA = {
     "name": "scope_recall_search",
-    "description": "Search Scope Recall memories relevant to a query across the current local scope plus shared durable scope.",
+    "description": "Search accessible Scope Recall memories.",
     "parameters": {
         "type": "object",
         "properties": {
-            "query": {"type": "string", "description": "What to search for."},
-            "limit": {"type": "integer", "description": "Maximum results to return."},
-            "include_trace": {"type": "boolean", "description": "Include the structured Recall Funnel trace for this query."},
+            "query": {"type": "string", "description": "Search query."},
+            "limit": {"type": "integer", "description": "Max results."},
+            "include_trace": {"type": "boolean", "description": "Include Recall Funnel trace."},
         },
         "required": ["query"],
+    },
+}
+
+SCOPE_RECALL_MEMORY_SCHEMA = {
+    "name": "scope_recall_memory",
+    "description": "Compact memory operations: inspect, feedback, update, merge, or forget by exact id.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "action": {"type": "string", "enum": ["inspect", "feedback", "update", "merge", "forget"], "description": "Operation."},
+            "id": {"type": "string", "description": "Memory id."},
+            "ids": {"type": "array", "items": {"type": "string"}, "description": "Memory ids for forget."},
+            "rating": {"type": "string", "description": "Feedback rating."},
+            "note": {"type": "string", "description": "Feedback note."},
+            "content": {"type": "string", "description": "Replacement or merged content."},
+            "target": {"type": "string", "enum": ["user", "memory", "project", "ops", "general"], "description": "Optional target."},
+            "target_id": {"type": "string", "description": "Merge target id."},
+            "source_ids": {"type": "array", "items": {"type": "string"}, "description": "Merge source ids."},
+            "source_candidate_id": {"type": "string", "description": "Optional merge audit candidate id."},
+        },
+        "required": ["action"],
+    },
+}
+
+SCOPE_RECALL_ENTITY_SCHEMA = {
+    "name": "scope_recall_entity",
+    "description": "Compact entity graph operations: probe memories for an entity or list related entities.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "action": {"type": "string", "enum": ["probe", "related"], "description": "Entity operation."},
+            "entity": {"type": "string", "description": "Entity/person/project/service."},
+            "limit": {"type": "integer", "description": "Max results."},
+        },
+        "required": ["action", "entity"],
     },
 }
 

--- a/tests/test_experience_tools.py
+++ b/tests/test_experience_tools.py
@@ -19,6 +19,7 @@ def provider(tmp_path):
         tmp_path,
         {
             "vector": {"enabled": False},
+            "tool_schema_profile": "standard",
             "maintenance_tools_enabled": True,
             "experience": {"prefetch_enabled": False},
         },

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -1448,13 +1448,16 @@ def test_cross_platform_identity_mapping_shares_durable_memory_but_not_local_scr
 def test_maintenance_tool_schemas_require_operator_config(provider):
     schemas = provider.get_tool_schemas()
     names = {schema["name"] for schema in schemas}
-    assert {"scope_recall_context", "scope_recall_probe", "scope_recall_related", "scope_recall_feedback"} <= names
+    assert {"scope_recall_context", "scope_recall_memory", "scope_recall_entity"} <= names
+    assert "scope_recall_probe" not in names
+    assert "scope_recall_related" not in names
+    assert "scope_recall_feedback" not in names
     assert "scope_recall_store_secret_index" not in names
     assert "scope_recall_dedupe" not in names
     assert "scope_recall_govern" not in names
     assert "scope_recall_repair" not in names
-    assert "scope_recall_export" in names
-    assert "scope_recall_stats" in names
+    assert "scope_recall_export" not in names
+    assert "scope_recall_stats" not in names
     store_schema = next(schema for schema in schemas if schema["name"] == "scope_recall_store")
     memory_types = set(store_schema["parameters"]["properties"]["memory_type"]["enum"])
     assert {"workflow", "tool_trace", "summary", "pitfall", "decision"} <= memory_types

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -99,6 +99,10 @@ def test_default_config_includes_documented_retrieval_top_k():
 
     assert source_config["retrieval"]["top_k"] == 5
     assert config_module.DEFAULT_CONFIG["retrieval"]["top_k"] == source_config["retrieval"]["top_k"]
+    assert source_config["tool_schema_profile"] == "compact"
+    assert config_module.DEFAULT_CONFIG["tool_schema_profile"] == "compact"
+    assert source_config["tool_schema_extra_tools"] == []
+    assert config_module.DEFAULT_CONFIG["tool_schema_extra_tools"] == []
 
 
 def test_scope_recall_stats_reports_journal_digest_health(tmp_path, monkeypatch):

--- a/tests/test_roadmap_observability.py
+++ b/tests/test_roadmap_observability.py
@@ -37,6 +37,7 @@ def _provider(tmp_path):
 def test_inspect_explain_and_benchmark_tools_are_registered(tmp_path):
     plugin = _provider(tmp_path)
     try:
+        plugin._config["tool_schema_profile"] = "standard"
         schemas = plugin.get_tool_schemas()
         names = {schema["name"] for schema in schemas}
 

--- a/tests/test_tool_hygiene.py
+++ b/tests/test_tool_hygiene.py
@@ -52,21 +52,71 @@ def _provider_with_config(tmp_path, config: dict):
     return plugin
 
 
-def test_default_schema_surface_hides_low_frequency_secret_index_tool(provider):
+def test_default_schema_surface_uses_compact_core_tools(provider):
     names = _schema_names(provider)
 
-    assert "scope_recall_store" in names
-    assert "scope_recall_search" in names
-    assert "scope_recall_profile" in names
-    assert "scope_recall_experience_preflight" in names
+    assert names == {
+        "scope_recall_store",
+        "scope_recall_search",
+        "scope_recall_context",
+        "scope_recall_profile",
+        "scope_recall_memory",
+        "scope_recall_entity",
+    }
     assert "scope_recall_store_secret_index" not in names
-    assert "scope_recall_export" in names
-    assert "scope_recall_stats" in names
-    assert "scope_recall_benchmark" in names
-    assert "scope_recall_experience_stats" in names
-    assert len(names) <= 21
+    assert "scope_recall_export" not in names
+    assert "scope_recall_stats" not in names
+    assert "scope_recall_benchmark" not in names
+    assert "scope_recall_experience_stats" not in names
 
     assert "secret_index_tools_enabled=true" in provider.handle_tool_call("scope_recall_store_secret_index", {"label": "test"})
+    assert "provider" in provider.handle_tool_call("scope_recall_stats", {})
+
+
+def test_standard_schema_profile_restores_legacy_read_only_tools(tmp_path):
+    plugin = _provider_with_config(
+        tmp_path,
+        {
+            "tool_schema_profile": "standard",
+            "vector": {"enabled": False},
+        },
+    )
+    try:
+        names = _schema_names(plugin)
+
+        assert "scope_recall_memory" not in names
+        assert "scope_recall_entity" not in names
+        assert "scope_recall_probe" in names
+        assert "scope_recall_related" in names
+        assert "scope_recall_feedback" in names
+        assert "scope_recall_export" in names
+        assert "scope_recall_stats" in names
+        assert "scope_recall_benchmark" in names
+        assert "scope_recall_experience_stats" in names
+        assert "scope_recall_store_secret_index" not in names
+        assert "scope_recall_govern" not in names
+        assert "scope_recall_forgetting_run" not in names
+    finally:
+        plugin.shutdown()
+
+
+def test_schema_extra_tools_expose_selected_diagnostics_without_standard_profile(tmp_path):
+    plugin = _provider_with_config(
+        tmp_path,
+        {
+            "tool_schema_extra_tools": ["scope_recall_stats", "scope_recall_benchmark", "scope_recall_store_secret_index"],
+            "vector": {"enabled": False},
+        },
+    )
+    try:
+        names = _schema_names(plugin)
+
+        assert "scope_recall_memory" in names
+        assert "scope_recall_stats" in names
+        assert "scope_recall_benchmark" in names
+        assert "scope_recall_store_secret_index" not in names
+    finally:
+        plugin.shutdown()
 
 
 def test_secret_index_schema_surface_is_explicit_opt_in(tmp_path):
@@ -81,14 +131,43 @@ def test_secret_index_schema_surface_is_explicit_opt_in(tmp_path):
         names = _schema_names(plugin)
 
         assert "scope_recall_store_secret_index" in names
-        assert "scope_recall_export" in names
-        assert "scope_recall_stats" in names
-        assert "scope_recall_benchmark" in names
-        assert "scope_recall_experience_stats" in names
+        assert "scope_recall_export" not in names
+        assert "scope_recall_stats" not in names
+        assert "scope_recall_benchmark" not in names
+        assert "scope_recall_experience_stats" not in names
         assert "scope_recall_govern" not in names
         assert "scope_recall_forgetting_run" not in names
     finally:
         plugin.shutdown()
+
+
+def test_compact_memory_and_entity_tools_dispatch_to_legacy_operations(provider):
+    created = _store(provider, "Compact schema memory entity AlphaProject prefers exact-id operations.", "project")
+    assert created["stored"] is True
+
+    inspected = json.loads(provider.handle_tool_call("scope_recall_memory", {"action": "inspect", "id": created["id"]}))
+    assert inspected["found"] is True
+    assert inspected["memory"]["id"] == created["id"]
+
+    feedback = json.loads(provider.handle_tool_call("scope_recall_memory", {"action": "feedback", "id": created["id"], "rating": "helpful"}))
+    assert feedback["updated"] is True
+
+    entity_probe = json.loads(provider.handle_tool_call("scope_recall_entity", {"action": "probe", "entity": "AlphaProject", "limit": 5}))
+    assert entity_probe["count"] >= 1
+
+    related = json.loads(provider.handle_tool_call("scope_recall_entity", {"action": "related", "entity": "AlphaProject", "limit": 5}))
+    assert "related" in related
+
+    updated = json.loads(
+        provider.handle_tool_call(
+            "scope_recall_memory",
+            {"action": "update", "id": created["id"], "content": "Compact schema memory update keeps AlphaProject searchable."},
+        )
+    )
+    assert updated["updated"] is True
+
+    deleted = json.loads(provider.handle_tool_call("scope_recall_memory", {"action": "forget", "id": created["id"]}))
+    assert deleted["deleted"] == 1
 
 
 def test_tool_store_uses_capture_filter_for_secret_like_content(provider):

--- a/tooling.py
+++ b/tooling.py
@@ -51,6 +51,8 @@ class ScopeRecallToolService:
             "scope_recall_store_secret_index": self._handle_store_secret_index,
             "scope_recall_search": self._handle_search,
             "scope_recall_context": self._handle_context,
+            "scope_recall_memory": self._handle_memory,
+            "scope_recall_entity": self._handle_entity,
             "scope_recall_profile": self._handle_profile,
             "scope_recall_probe": self._handle_probe,
             "scope_recall_related": self._handle_related,
@@ -293,6 +295,35 @@ class ScopeRecallToolService:
         if not entity:
             return tool_error("entity is required")
         return self._json(self.provider._related_entities(entity=entity, limit=self._limit(args)))
+
+    def _handle_memory(self, args: dict[str, Any]) -> str:
+        action = str(args.get("action") or "").strip().lower().replace("-", "_")
+        aliases = {
+            "rate": "feedback",
+            "delete": "forget",
+            "remove": "forget",
+            "get": "inspect",
+        }
+        action = aliases.get(action, action)
+        if action == "inspect":
+            return self._handle_inspect(args)
+        if action == "feedback":
+            return self._handle_feedback(args)
+        if action == "update":
+            return self._handle_update(args)
+        if action == "merge":
+            return self._handle_merge(args)
+        if action == "forget":
+            return self._handle_forget(args)
+        return tool_error("action must be one of: inspect, feedback, update, merge, forget")
+
+    def _handle_entity(self, args: dict[str, Any]) -> str:
+        action = str(args.get("action") or "").strip().lower().replace("-", "_")
+        if action == "probe":
+            return self._handle_probe(args)
+        if action in {"related", "relations"}:
+            return self._handle_related(args)
+        return tool_error("action must be one of: probe, related")
 
     def _handle_feedback(self, args: dict[str, Any]) -> str:
         memory_id = str(args.get("id") or "").strip()


### PR DESCRIPTION
## Summary

Completes the schema-footprint work requested in #18.

This PR changes the default provider tool schema surface from the previous broad read-only/diagnostic set to a compact profile:

- default `tool_schema_profile="compact"`
- default schema: 6 tools / ~4.7 KB JSON schema in repo-local measurement
- standard compatibility profile: 20 tools / ~10.6 KB
- direct-call compatibility is preserved for legacy individual tools
- `tool_schema_extra_tools` can selectively expose diagnostics while staying compact

## Main changes

- Adds compact dispatch tools:
  - `scope_recall_memory(action=inspect|feedback|update|merge|forget, ...)`
  - `scope_recall_entity(action=probe|related, ...)`
- Adds config knobs:
  - `tool_schema_profile`: `compact` (default) or `standard`/`legacy`/`compat`
  - `tool_schema_extra_tools`: list or comma-separated string of additional allowed schemas to expose
- Keeps safety gates:
  - `scope_recall_store_secret_index` still requires `secret_index_tools_enabled=true`
  - maintenance/mutation tools still require `maintenance_tools_enabled=true`
- Shortens several core schema descriptions.
- Updates README, stability docs, changelog, and regression tests.

## Schema measurements

Repo-local provider measurements after this PR:

- default compact: 6 tools, 4,710 bytes
- standard profile: 20 tools, 10,624 bytes
- compact + selected diagnostics (`stats`, `benchmark`): 8 tools, 6,209 bytes
- secret opt-in: 7 tools, 6,407 bytes

Relative to the current post-#20 default of 20 tools / 11,028 bytes, the new default is about a 57% byte reduction.

## Verification

- `python3 -m py_compile schemas.py provider.py tooling.py config.py tests/test_tool_hygiene.py tests/test_provider.py tests/test_experience_tools.py tests/test_roadmap_observability.py tests/test_release.py`
- `ruff check`
- `pyright`
- focused schema/tool tests: `15 passed`
- full `python3 -m pytest -q` → `449 passed, 1 skipped`
- `python3 scripts/check.release.py --allow-dirty` → `ok: true`
- strict clean `python3 scripts/check.release.py` after commit → `ok: true`

Fixes #18.
