### PR TITLE
feat: curated-memory dedupe controls, retrieval and doctor fixes

### DIFF
--- a/candidate_store.py
+++ b/candidate_store.py
@@ -14,8 +14,9 @@ import uuid
 from typing import Any, Iterable
 
 from .candidate_extraction import ExtractedCandidate
+from .memory_text_merge import curated_entry_covering_candidate
 from .models import RuntimeScope
-from .sql_store import record_governance_audit_event, store_row
+from .sql_store import curated_recall_item_id, record_governance_audit_event, store_row
 
 
 def _candidate_metadata(candidate: ExtractedCandidate) -> dict[str, Any]:
@@ -40,17 +41,25 @@ def store_event_candidates(
     scope_id: str,
     session_id: str,
     dry_run: bool = True,
+    curated_entries: Iterable[tuple[str, str, str]] = (),
 ) -> dict[str, Any]:
     """Store one event-candidate batch atomically when explicitly enabled."""
 
     candidate_list = list(candidates)
+    curated_entry_list = list(curated_entries)
+    curated_matches = [
+        curated_entry_covering_candidate(candidate.content, curated_entry_list)
+        for candidate in candidate_list
+    ]
     report: dict[str, Any] = {
         "ok": True,
         "dry_run": dry_run,
         "planned": len(candidate_list),
         "inserted": 0,
         "updated_existing": 0,
+        "skipped_curated_duplicate": sum(match is not None for match in curated_matches),
         "ids": [],
+        "curated_ids": [],
     }
     if dry_run or not candidate_list:
         return report
@@ -61,7 +70,30 @@ def store_event_candidates(
     savepoint = f"event_candidates_{uuid.uuid4().hex}"
     conn.execute(f"SAVEPOINT {savepoint}")
     try:
-        for candidate in candidate_list:
+        for candidate, curated_match in zip(candidate_list, curated_matches):
+            if curated_match is not None:
+                curated_target, curated_content, _updated_at = curated_match
+                curated_id = curated_recall_item_id(curated_target, curated_content)
+                report["curated_ids"].append(curated_id)
+                record_governance_audit_event(
+                    conn,
+                    event_id=f"event-candidate-audit-{uuid.uuid4().hex}",
+                    event_type="event_candidate",
+                    action="skip_curated_duplicate",
+                    scope_id=scope_id,
+                    target_id=curated_id,
+                    before={},
+                    after={
+                        "target": candidate.target,
+                        "memory_type": candidate.memory_type,
+                        "lifecycle": "candidate_rejected",
+                        "evidence_refs": list(candidate.evidence_refs),
+                    },
+                    reason="curated memory covers candidate",
+                    actor="scope-recall:event-digest",
+                    dry_run=False,
+                )
+                continue
             memory_id = f"event-candidate-{uuid.uuid4().hex}"
             metadata = _candidate_metadata(candidate)
             stored_id, summary, updated_at, inserted = store_row(

--- a/config.json
+++ b/config.json
@@ -163,7 +163,10 @@
   },
   "curated_memory": {
     "mode": "single-user",
-    "allowed_user_ids": []
+    "allowed_user_ids": [],
+    "auto_recall": true,
+    "include_in_tools": true,
+    "dedupe_candidates": true
   },
   "identity": {
     "cross_platform_shared_scope": false,

--- a/config.py
+++ b/config.py
@@ -174,6 +174,9 @@ DEFAULT_CONFIG: dict[str, Any] = {
     "curated_memory": {
         "mode": "single-user",
         "allowed_user_ids": [],
+        "auto_recall": True,
+        "include_in_tools": True,
+        "dedupe_candidates": True,
     },
     "shared_pool": {
         "enabled": False,

--- a/config_schema.py
+++ b/config_schema.py
@@ -11,6 +11,9 @@ from typing import Any
 _DESCRIPTION_OVERRIDES = {
     "auto_recall": "Enable automatic recall injection at turn start.",
     "auto_capture": "Capture eligible conversation turns into Scope Recall.",
+    "curated_memory.auto_recall": "Include live USER.md/MEMORY.md rows in automatic current-turn recall. Disable this when Hermes already injects curated files into the system prompt.",
+    "curated_memory.include_in_tools": "Keep live USER.md/MEMORY.md rows available to explicit Scope Recall profile/search tools.",
+    "curated_memory.dedupe_candidates": "Reject automatic candidates already strictly covered by live USER.md/MEMORY.md authority while keeping an audit receipt.",
     "memory_isolated_chat_ids": "Runtime-only chat identifiers excluded from prompt recall, tools, capture, journal, and digest surfaces.",
     "journal.max_entries_per_digest": "Maximum journal entries a digest run may review before dynamic backlog expansion.",
     "journal.retention_profile": "Semantic digest detail: light keeps only minimal durable facts, balanced preserves useful rationale and steps, and full preserves detailed durable context while raw transcript evidence remains in the journal.",

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -61,6 +61,9 @@ This file is generated from the packaged `config.json` registry. It lists every 
 ## `curated_memory`
 
 - `curated_memory.allowed_user_ids` (array; risk: `low`; restart_required: `no`) — Scope Recall configuration key `curated_memory.allowed_user_ids` in the `curated_memory` group. Default: `[]`
+- `curated_memory.auto_recall` (boolean; risk: `low`; restart_required: `no`) — Include live USER.md/MEMORY.md rows in automatic current-turn recall. Disable this when Hermes already injects curated files into the system prompt. Default: `true`
+- `curated_memory.dedupe_candidates` (boolean; risk: `low`; restart_required: `no`) — Reject automatic candidates already strictly covered by live USER.md/MEMORY.md authority while keeping an audit receipt. Default: `true`
+- `curated_memory.include_in_tools` (boolean; risk: `low`; restart_required: `no`) — Keep live USER.md/MEMORY.md rows available to explicit Scope Recall profile/search tools. Default: `true`
 - `curated_memory.mode` (string; risk: `low`; restart_required: `no`; choices: `single-user, explicit-users, profile-global, disabled`) — Scope Recall configuration key `curated_memory.mode` in the `curated_memory` group. Default: `"single-user"`
 
 ## `enable_tools`

--- a/doctor_journal.py
+++ b/doctor_journal.py
@@ -372,6 +372,13 @@ def journal_report(hermes_home: Path, *, enabled: bool = True, journal_config: d
     digest_health_reasons: list[str] = []
     recent_bad_runs = sum(recent_status_counts.get(status, 0) for status in ("error", "retry_scheduled", "dead_letter"))
     recent_fallback_runs = recent_status_counts.get("ok_with_fallback", 0) + recent_extractor_counts.get("heuristic-fallback", 0)
+    raw_background_digest_enabled = journal_config.get("background_digest_enabled", False)
+    background_digest_enabled = (
+        raw_background_digest_enabled.strip().lower() in {"1", "true", "yes", "on"}
+        if isinstance(raw_background_digest_enabled, str)
+        else bool(raw_background_digest_enabled)
+    )
+    latest_digest_status = str(last_run["status"] or "") if last_run is not None else ""
     recent_quarantine_runs = sum(
         1
         for row in recent_runs
@@ -382,6 +389,13 @@ def journal_report(hermes_home: Path, *, enabled: bool = True, journal_config: d
         digest_health_status = "degraded"
         digest_health_reasons.append("recent_digest_failures_or_quarantine")
         recommendations.append("Journal digest recently failed or quarantined LLM batches; inspect retry/dead-letter health before relying on automated summaries.")
+    if background_digest_enabled and latest_digest_status in {"error", "retry_scheduled", "dead_letter"}:
+        failures.append(
+            f"latest background journal digest run failed with status {latest_digest_status}"
+        )
+        recommendations.append(
+            "Fix and rerun the background journal digest before treating automated memory consolidation as healthy."
+        )
     if recent_fallback_runs:
         digest_health_status = "degraded"
         digest_health_reasons.append("recent_heuristic_fallback")

--- a/gating.py
+++ b/gating.py
@@ -88,6 +88,10 @@ _OPERATING_SYSTEM_QUERY_RE = re.compile(
     r"(?:什么|哪个|哪种)(?:操作)?系统)"
 )
 _TIMEZONE_QUERY_RE = re.compile(r"(?:\btime\s*zone\b|\btimezone\b|时区)", re.IGNORECASE)
+_ATTRIBUTE_QUERY_RE = re.compile(
+    r"(?:^|的)(?P<subject>[\u4e00-\u9fffA-Za-z0-9_.-]{2,16})"
+    r"(?P<attribute>型号|版本|名称|名字)(?:是|为)?(?:什么|哪个|哪一个|哪种)?"
+)
 _LOCATION_INTENT_TERMS = ("位置", "地址", "路径", "目录", "主机", "本机", "运行环境")
 _OPERATING_SYSTEM_INTENT_TERMS = (
     "操作系统",
@@ -403,6 +407,15 @@ def matched_query_intent_terms(query: str, document: str) -> List[str]:
         ):
             terms.extend(_TIMEZONE_INTENT_TERMS)
             terms.append(timezone_value.group(0).casefold())
+    attribute_match = _ATTRIBUTE_QUERY_RE.search(normalized_query)
+    if attribute_match is not None:
+        subject = attribute_match.group("subject").casefold()
+        attribute = attribute_match.group("attribute").casefold()
+        answer_relation = re.compile(
+            rf"{re.escape(subject)}(?:的)?(?:型号|版本|名称|名字)?\s*(?:是|为|:|：)"
+        )
+        if subject in normalized_document and answer_relation.search(normalized_document):
+            terms.extend((subject, attribute))
     return [term for term in dict.fromkeys(terms) if term in normalized_document]
 
 

--- a/graph.py
+++ b/graph.py
@@ -231,11 +231,6 @@ def _is_tool_trace_entity(lowered: str) -> bool:
         return True
     if any(lowered.endswith(suffix) for suffix in _TOOL_TRACE_ENTITY_SUFFIXES):
         return True
-    # Most snake_case tokens from tool logs are implementation/procedure noise,
-    # not durable world entities. Stored legacy metadata can still contain such
-    # rows, so read surfaces also call normalize_entity as a defensive filter.
-    if "_" in lowered:
-        return True
     if lowered.startswith(("/tmp/", "/home/", "file://")):
         return True
     return False

--- a/journal.py
+++ b/journal.py
@@ -29,6 +29,7 @@ from .fact_evolution import (
 )
 from .gating import clean_text, compact_text, dedup_key
 from .governance import semantic_similarity
+from .memory_text_merge import curated_entry_covering_candidate
 from .maintenance_lease import install_activation_lease_authorizer
 from .models import RuntimeScope, recall_scope_id_for_target
 from .truth_connection import connect_truth_database
@@ -90,7 +91,8 @@ from .journal_store import (
 )
 from .scope import accessible_scope_ids, build_scope_id, build_shared_scope_id, canonical_user_id, normalize_scope_identity, writable_scope_ids
 from .source_isolation import memory_isolated_chat_ids, scope_is_memory_isolated
-from .sql_store import ensure_schema, now_iso, store_row
+from .sql_store import curated_recall_item_id, ensure_schema, iter_curated_entries, now_iso, store_row
+from .storage_views import curated_memory_policy_allows
 from .vector_runtime import replay_vector_outbox, vector_write_replay_limit
 
 # Compatibility surface: tests and operator probes historically monkeypatch
@@ -1006,6 +1008,7 @@ def apply_journal_candidates(
     candidates: list[JournalDigestCandidate],
     dry_run: bool = False,
     runtime_config: dict[str, Any] | None = None,
+    curated_entries: list[tuple[str, str, str]] | None = None,
     _skip_components: bool = False,
     _defer_commits: bool = False,
     _deferred_vector_ops: list[dict[str, Any]] | None = None,
@@ -1021,6 +1024,39 @@ def apply_journal_candidates(
     pollution_counts = Counter()
     actions: list[dict[str, Any]] = []
     processed_entry_ids: set[int] = set()
+    remaining_candidates: list[JournalDigestCandidate] = []
+    curated_entry_list = list(curated_entries or [])
+    for candidate in candidates:
+        curated_match = curated_entry_covering_candidate(
+            candidate.content,
+            curated_entry_list,
+        )
+        if curated_match is None:
+            remaining_candidates.append(candidate)
+            continue
+        curated_target, curated_content, _updated_at = curated_match
+        curated_id = curated_recall_item_id(curated_target, curated_content)
+        counts["skipped"] += 1
+        actions.append(
+            {
+                "action": "skip",
+                "reason": "curated memory covers candidate",
+                "id": curated_id,
+                "entry_ids": candidate.entry_ids,
+            }
+        )
+        processed_entry_ids.update(int(entry_id) for entry_id in candidate.entry_ids)
+        if not dry_run:
+            _record_journal_rejection(
+                conn,
+                run_id=run_id,
+                entry_ids=candidate.entry_ids,
+                reason="curated memory covers candidate",
+                candidate=candidate,
+            )
+            if not _defer_commits:
+                conn.commit()
+    candidates = remaining_candidates
     pollution_assessments = assess_digest_batch(
         candidates,
         batch_evidence=_journal_candidate_source_evidence(conn, candidates),
@@ -1576,6 +1612,17 @@ def run_journal_digest(
                     )
                 except Exception:
                     vector_runtime = None
+            curated_config = runtime_config.get("curated_memory", {})
+            curated_config = curated_config if isinstance(curated_config, dict) else {}
+            candidate_curated_entries = (
+                iter_curated_entries(hermes_home)
+                if _config_bool(curated_config, "dedupe_candidates", True)
+                and curated_memory_policy_allows(
+                    runtime_config,
+                    user_id=active_scope.user_id,
+                )
+                else []
+            )
             applied = apply_journal_candidates(
                 conn,
                 vector_runtime,
@@ -1584,6 +1631,7 @@ def run_journal_digest(
                 candidates=candidates,
                 dry_run=dry_run,
                 runtime_config=runtime_config,
+                curated_entries=candidate_curated_entries,
             )
             counts.update(applied["counts"])
             quarantine_counts.update(applied.get("pollution_counts", {}))

--- a/memory_text_merge.py
+++ b/memory_text_merge.py
@@ -6,6 +6,7 @@ similar assertions.  It exists for explicit/manual merges and audited cleanup.
 from __future__ import annotations
 
 import re
+from collections.abc import Iterable
 
 _SEGMENT_RE = re.compile(r"(?:\s*\n\s*§\s*\n\s*|\s+/\s+)")
 _KEY_RE = re.compile(r"[^a-z0-9\u4e00-\u9fff]+", re.IGNORECASE)
@@ -36,6 +37,23 @@ def automatic_merge_is_safe(existing: str, candidate: str) -> bool:
     if min(len(existing_key), len(candidate_key)) < 12:
         return False
     return existing_key in candidate_key or candidate_key in existing_key
+
+
+def curated_entry_covering_candidate(
+    candidate: str,
+    curated_entries: Iterable[tuple[str, str, str]],
+) -> tuple[str, str, str] | None:
+    """Return the first authoritative curated entry that strictly covers a candidate.
+
+    This deliberately reuses the conservative exact/containment gate above.
+    Semantic similarity alone is not enough to discard an automatic candidate:
+    one changed number, polarity, or timestamp must remain reviewable.
+    """
+
+    for target, content, updated_at in curated_entries:
+        if automatic_merge_is_safe(content, candidate):
+            return str(target), str(content), str(updated_at)
+    return None
 
 
 def deduplicate_memory_text(text: str) -> str:

--- a/nightly_llm.py
+++ b/nightly_llm.py
@@ -160,11 +160,16 @@ def resolve_llm_config(hermes_home: Path, options: Any) -> dict[str, Any]:
         or model_cfg.get("default_model")
         or "gpt-4o-mini"
     )
+    provider_default_base_url = (
+        "https://chatgpt.com/backend-api/codex"
+        if provider.lower() == "openai-codex"
+        else "https://api.openai.com"
+    )
     base_url = getattr(options, "base_url", "") or str(
         nightly_cfg.get("base_url")
         or provider_cfg.get("base_url")
         or model_cfg.get("base_url")
-        or "https://api.openai.com"
+        or provider_default_base_url
     )
     endpoint = getattr(options, "endpoint", "") or str(
         nightly_cfg.get("endpoint")
@@ -533,6 +538,8 @@ def classify_llm_error(exc: Exception) -> tuple[str, bool]:
         return "rate_limit", True
     if any(token in message for token in ("500", "502", "503", "504", "server error", "bad gateway", "service unavailable", "gateway timeout")):
         return "server", True
+    if "404" in message or "not found" in message:
+        return "endpoint_config", False
     if any(token in message for token in ("connection", "network", "temporarily", "reset by peer", "remote end closed")):
         return "network", True
     if any(token in message for token in ("401", "403", "unauthorized", "forbidden", "invalid api key", "permission")):

--- a/prompting.py
+++ b/prompting.py
@@ -25,7 +25,11 @@ def render_current_turn_recall(provider: Any, query: str) -> str:
     if should_skip_retrieval(normalized_query, int(provider._config_value("auto_recall_min_length", 15))):
         return ""
 
-    results = provider._recall_service.search_memories(normalized_query, limit=provider._retrieve_limit())
+    results = provider._recall_service.search_memories(
+        normalized_query,
+        limit=provider._retrieve_limit(),
+        include_curated=_curated_auto_recall_enabled(provider),
+    )
     results = _drop_recently_recalled(provider, results)
     selected = _select_recall_items(provider, results)
     if not selected:
@@ -67,6 +71,21 @@ def render_current_turn_recall(provider: Any, query: str) -> str:
 
 def _should_attempt_recall(provider: Any) -> bool:
     return config_bool(provider._config, "auto_recall", True) and provider._scope.agent_context == "primary"
+
+
+def _curated_auto_recall_enabled(provider: Any) -> bool:
+    """Return whether Hermes-curated rows may enter the automatic prompt block.
+
+    Tool/profile searches use a separate policy.  This split lets deployments
+    keep USER.md/MEMORY.md as live searchable authority while avoiding a second
+    copy when Hermes already injects those files into the system prompt.
+    """
+
+    raw_config = (provider._config or {}).get("curated_memory", {})
+    if raw_config is False:
+        return False
+    config = raw_config if isinstance(raw_config, dict) else {}
+    return config_bool(config, "auto_recall", True)
 
 
 def _drop_recently_recalled(provider: Any, results: list[RecallItem]) -> list[RecallItem]:

--- a/provider.py
+++ b/provider.py
@@ -75,9 +75,9 @@ from .scope import (
     writable_scope_ids,
 )
 from .source_isolation import scope_is_memory_isolated
-from .sql_store import ensure_schema
+from .sql_store import ensure_schema, iter_curated_entries
 
-from .storage_views import search_curated_memories, search_db_memories, search_vector_memories
+from .storage_views import curated_memory_policy_allows, search_curated_memories, search_db_memories, search_vector_memories
 from .tooling import ScopeRecallToolService
 from .truth_connection import connect_truth_database
 from .vector_bootstrap import bootstrap_fresh_vector_companion
@@ -731,6 +731,17 @@ class ScopeRecallMemoryProvider(MemoryProvider):
                 rejected += 1
                 reasons.update(extraction.rejection_reasons)
         with self._lock:
+            curated_config = self._config.get("curated_memory", {})
+            curated_config = curated_config if isinstance(curated_config, dict) else {}
+            curated_entries = (
+                iter_curated_entries(self._hermes_home)
+                if config_bool(curated_config, "dedupe_candidates", True)
+                and curated_memory_policy_allows(
+                    self._config,
+                    user_id=self._scope.user_id,
+                )
+                else []
+            )
             store_report = store_event_candidates(
                 self._require_conn(),
                 candidates=proposed_candidates,
@@ -738,6 +749,7 @@ class ScopeRecallMemoryProvider(MemoryProvider):
                 scope_id=self._scope_id,
                 session_id=self._session_id,
                 dry_run=dry_run,
+                curated_entries=curated_entries,
             )
         report.update(
             {

--- a/recall.py
+++ b/recall.py
@@ -163,6 +163,7 @@ class RecallService:
         *,
         limit: int,
         recall_mode: str = "advisory",
+        include_curated: bool = True,
     ) -> list[RecallItem]:
         """Search accessible memory sources and return ranked recall payloads.
 
@@ -209,8 +210,13 @@ class RecallService:
         trace["timings_ms"]["vector"] = self._elapsed_ms(stage_start)
 
         stage_start = time.perf_counter()
-        curated_candidates = self.provider._search_curated_memories(query)
+        curated_candidates = (
+            self.provider._search_curated_memories(query)
+            if include_curated
+            else []
+        )
         trace["stages"]["curated"] = self._trace_stage(curated_candidates)
+        trace["stages"]["curated"]["enabled"] = bool(include_curated)
         trace["timings_ms"]["curated"] = self._elapsed_ms(stage_start)
 
         temporal_candidates: list[RecallItem] = []

--- a/scripts/doctor.py
+++ b/scripts/doctor.py
@@ -212,7 +212,7 @@ def main() -> int:
     payload["ok"] = contract_ok and all(
         bool(check.get("ok")) for check in checks.values()
     )
-    print(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True))
+    print(json.dumps(payload, ensure_ascii=True, indent=2, sort_keys=True))
     return 0 if payload["ok"] else 1
 
 

--- a/storage_views.py
+++ b/storage_views.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import sqlite3
 from typing import Any
 
-from .gating import build_fts_query, compact_text, like_terms, normalized_token_set, retrieval_query_tokens
+from .gating import build_fts_query, compact_text, config_bool, like_terms, normalized_token_set, retrieval_query_tokens
 from .governance import classify_memory
 from .graph import load_metadata
 from .lifecycle_policy import ORDINARY_RECALL_HIDDEN_LIFECYCLE_VALUES, ordinary_recall_lifecycle_visible_sql
@@ -278,8 +278,14 @@ def search_vector_memories(provider: Any, query: str, *, limit: int) -> list[Rec
     return results
 
 
-def _curated_memory_allowed(provider: Any) -> bool:
-    raw_cfg = (provider._config or {}).get("curated_memory", {})
+def curated_memory_policy_allows(
+    runtime_config: dict[str, Any] | None,
+    *,
+    user_id: str = "",
+) -> bool:
+    """Return whether one runtime identity may read profile-global curated files."""
+
+    raw_cfg = (runtime_config or {}).get("curated_memory", {})
     if raw_cfg is False:
         return False
     cfg = raw_cfg if isinstance(raw_cfg, dict) else {}
@@ -287,11 +293,10 @@ def _curated_memory_allowed(provider: Any) -> bool:
     if mode in {"disabled", "off", "false", "none"}:
         return False
 
-    scope = getattr(provider, "_scope", None)
-    user_id = str(getattr(scope, "user_id", "") or "")
+    clean_user_id = str(user_id or "")
     allowed = [str(item).strip() for item in (cfg.get("allowed_user_ids") or []) if str(item).strip()]
     if allowed:
-        return bool(user_id and user_id in allowed)
+        return bool(clean_user_id and clean_user_id in allowed)
     if mode in {"explicit-users", "allow-list", "allowlist"}:
         return False
     if mode in {"shared"}:
@@ -303,7 +308,17 @@ def _curated_memory_allowed(provider: Any) -> bool:
     # Safe default: global curated files may be injected only when Hermes is not
     # running with an explicit gateway user id. Provider-owned SQLite rows remain
     # the scoped durable store for multi-user contexts.
-    return not bool(user_id)
+    return not bool(clean_user_id)
+
+
+def _curated_memory_allowed(provider: Any) -> bool:
+    raw_cfg = (provider._config or {}).get("curated_memory", {})
+    cfg = raw_cfg if isinstance(raw_cfg, dict) else {}
+    if not config_bool(cfg, "include_in_tools", True):
+        return False
+    scope = getattr(provider, "_scope", None)
+    user_id = str(getattr(scope, "user_id", "") or "")
+    return curated_memory_policy_allows(provider._config, user_id=user_id)
 
 
 def search_curated_memories(provider: Any, query: str) -> list[RecallItem]:

--- a/tests/test_curated_dedup.py
+++ b/tests/test_curated_dedup.py
@@ -1,0 +1,158 @@
+"""Regression tests for curated-memory prompt and candidate deduplication."""
+
+from __future__ import annotations
+
+import sqlite3
+
+from scope_recall.candidate_extraction import ExtractedCandidate
+from scope_recall.candidate_store import store_event_candidates
+from scope_recall.config_schema import build_config_registry, load_packaged_config
+from scope_recall.journal import JournalDigestCandidate, apply_journal_candidates, ensure_journal_schema
+from scope_recall.models import RuntimeScope
+from scope_recall.sql_store import ensure_schema
+from scope_recall.storage_views import search_curated_memories
+
+
+def _scope() -> RuntimeScope:
+    return RuntimeScope(
+        platform="cli",
+        user_id="jojo",
+        chat_id="local",
+        agent_identity="default",
+        agent_workspace="hermes",
+    )
+
+
+def _connection(tmp_path) -> sqlite3.Connection:
+    conn = sqlite3.connect(tmp_path / "memory.sqlite3")
+    conn.row_factory = sqlite3.Row
+    ensure_schema(conn)
+    ensure_journal_schema(conn)
+    return conn
+
+
+def test_curated_memory_split_controls_are_registered() -> None:
+    curated = load_packaged_config()["curated_memory"]
+    assert curated["auto_recall"] is True
+    assert curated["include_in_tools"] is True
+    assert curated["dedupe_candidates"] is True
+    keys = {row["key"] for row in build_config_registry()}
+    assert {
+        "curated_memory.auto_recall",
+        "curated_memory.include_in_tools",
+        "curated_memory.dedupe_candidates",
+    } <= keys
+
+
+def test_curated_tool_surface_can_be_disabled_independently(tmp_path) -> None:
+    memories = tmp_path / "memories"
+    memories.mkdir()
+    (memories / "USER.md").write_text("User prefers concise reports.", encoding="utf-8")
+    provider = type(
+        "Provider",
+        (),
+        {
+            "_config": {
+                "curated_memory": {
+                    "mode": "profile-global",
+                    "auto_recall": False,
+                    "include_in_tools": False,
+                }
+            },
+            "_scope": type("Scope", (), {"user_id": "jojo"})(),
+            "_retrieval_config": {"min_score": 0.0},
+            "_hermes_home": tmp_path,
+            "_config_value": staticmethod(lambda _key, default: default),
+        },
+    )()
+
+    assert search_curated_memories(provider, "concise reports") == []
+
+
+def test_event_candidate_strictly_covered_by_curated_memory_is_not_stored(tmp_path) -> None:
+    conn = _connection(tmp_path)
+    content = "User prefers concise Chinese answers with verified results."
+    report = store_event_candidates(
+        conn,
+        candidates=[
+            ExtractedCandidate(
+                target="user",
+                content=content,
+                memory_type="preference",
+                confidence=0.9,
+                evidence_refs=["session:test:turn:1"],
+            )
+        ],
+        scope=_scope(),
+        scope_id="scope-a",
+        session_id="session-a",
+        dry_run=False,
+        curated_entries=[("user", f"Profile heading\n{content}\nStable footer", "2026-08-05T00:00:00+00:00")],
+    )
+
+    assert report["inserted"] == 0
+    assert report["skipped_curated_duplicate"] == 1
+    assert conn.execute("SELECT COUNT(*) FROM memories").fetchone()[0] == 0
+    audit = conn.execute("SELECT action FROM governance_audit_events").fetchone()
+    assert audit["action"] == "skip_curated_duplicate"
+
+
+def test_changed_value_is_not_discarded_as_curated_duplicate(tmp_path) -> None:
+    conn = _connection(tmp_path)
+    report = store_event_candidates(
+        conn,
+        candidates=[
+            ExtractedCandidate(
+                target="project",
+                content="The alert threshold is 28 centimeters.",
+                memory_type="project_fact",
+                confidence=0.9,
+                evidence_refs=["session:test:turn:2"],
+            )
+        ],
+        scope=_scope(),
+        scope_id="scope-a",
+        session_id="session-a",
+        dry_run=False,
+        curated_entries=[
+            (
+                "memory",
+                "The alert threshold is 27 centimeters.",
+                "2026-08-05T00:00:00+00:00",
+            )
+        ],
+    )
+
+    assert report["skipped_curated_duplicate"] == 0
+    assert report["inserted"] == 1
+
+
+def test_journal_candidate_strictly_covered_by_curated_memory_is_rejected_with_receipt(tmp_path) -> None:
+    conn = _connection(tmp_path)
+    content = "The project uses pytest for verification."
+    candidate = JournalDigestCandidate(
+        content=content,
+        target="project",
+        memory_type="project_fact",
+        entry_ids=[41],
+        session_ids=["session-a"],
+    )
+
+    result = apply_journal_candidates(
+        conn,
+        None,
+        _scope(),
+        run_id="curated-dedup",
+        candidates=[candidate],
+        dry_run=False,
+        curated_entries=[("memory", f"Stable environment: {content}", "2026-08-05T00:00:00+00:00")],
+    )
+
+    assert result["counts"]["skipped"] == 1
+    assert result["processed_entry_ids"] == [41]
+    assert result["actions"][0]["reason"] == "curated memory covers candidate"
+    assert conn.execute("SELECT COUNT(*) FROM memories").fetchone()[0] == 0
+    receipt = conn.execute(
+        "SELECT reason FROM journal_rejections WHERE journal_entry_id = 41"
+    ).fetchone()
+    assert receipt["reason"] == "curated memory covers candidate"

--- a/tests/test_doctor_journal_health.py
+++ b/tests/test_doctor_journal_health.py
@@ -174,6 +174,38 @@ def test_journal_report_fails_when_provider_risk_no_insert_streak_exceeds_thresh
     assert any("no productive writes" in item for item in recommendations)
 
 
+def test_journal_report_fails_when_enabled_background_digest_latest_run_failed(tmp_path):
+    conn = _conn(tmp_path)
+    conn.execute(
+        """
+        INSERT INTO journal_digest_runs(
+            id, started_at, finished_at, status, extractor,
+            processed_entries, inserted, updated, skipped, error, metadata
+        ) VALUES (
+            'run-background-error',
+            '2026-01-05T00:00:00+00:00',
+            '2026-01-05T00:00:01+00:00',
+            'error', 'llm-error', 0, 0, 0, 0,
+            'endpoint_config after 1 attempt',
+            '{"health_flags":["extractor_error"]}'
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+    doctor = _doctor_module()
+
+    payload, check, recommendations = doctor.journal_report(
+        tmp_path,
+        journal_config={"background_digest_enabled": True},
+    )
+
+    assert check["ok"] is False
+    assert payload["digest_health"]["status"] == "degraded"
+    assert any("latest background journal digest run failed" in item for item in check["failures"])
+    assert any("background journal digest" in item.lower() for item in recommendations)
+
+
 def test_journal_risk_streak_resets_after_productive_run(tmp_path):
     conn = _conn(tmp_path)
     risk_metadata = json.dumps(

--- a/tests/test_doctor_output_encoding.py
+++ b/tests/test_doctor_output_encoding.py
@@ -1,0 +1,44 @@
+"""Regression tests for the doctor CLI output encoding contract."""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import sys
+from pathlib import Path
+
+
+def test_doctor_json_stdout_is_utf8_safe_under_cp936_console(monkeypatch, tmp_path: Path) -> None:
+    """Machine JSON must remain UTF-8 decodable on Chinese Windows consoles."""
+
+    from scripts import doctor
+
+    monkeypatch.setattr(
+        doctor,
+        "parse_args",
+        lambda: argparse.Namespace(
+            json=True,
+            source_root=str(tmp_path),
+            hermes_home="",
+        ),
+    )
+    monkeypatch.setattr(
+        doctor,
+        "source_report",
+        lambda _root: (
+            {"description": "中文健康状态"},
+            {"ok": True},
+            [],
+        ),
+    )
+
+    raw = io.BytesIO()
+    console = io.TextIOWrapper(raw, encoding="cp936", newline="\n")
+    monkeypatch.setattr(sys, "stdout", console)
+
+    assert doctor.main() == 0
+    console.flush()
+
+    payload = json.loads(raw.getvalue().decode("utf-8"))
+    assert payload["source"]["description"] == "中文健康状态"

--- a/tests/test_entity_quality.py
+++ b/tests/test_entity_quality.py
@@ -30,3 +30,14 @@ def test_generic_or_hybrid_entity_noise_is_rejected(value: str) -> None:
 def test_stable_names_and_identifiers_remain_indexable(value: str) -> None:
     assert entity_is_indexable(value) is True
     assert normalize_entity(value)
+
+
+@pytest.mark.parametrize("value", ["notebook_model", "user_laptop", "model_name"])
+def test_stable_snake_case_identifiers_remain_indexable(value: str) -> None:
+    assert entity_is_indexable(value) is True
+    assert normalize_entity(value) == value
+
+
+@pytest.mark.parametrize("value", ["read_file", "browser_click", "terminal_tool"])
+def test_tool_trace_snake_case_entities_remain_rejected(value: str) -> None:
+    assert normalize_entity(value) == ""

--- a/tests/test_governance_contract_regressions.py
+++ b/tests/test_governance_contract_regressions.py
@@ -128,6 +128,33 @@ def test_store_and_merge_return_contract_receipts(tmp_path, monkeypatch):
     assert merged["receipt"]["source_candidate_id"] == "tcand-demo"
 
 
+def test_store_receipt_reports_actual_candidate_lifecycle(tmp_path, monkeypatch):
+    monkeypatch.delenv("SCOPE_RECALL_GEMINI_EMBEDDING_API_KEY", raising=False)
+    provider = _provider(tmp_path)
+    try:
+        payload = json.loads(
+            provider.handle_tool_call(
+                "scope_recall_store",
+                {
+                    "content": "Temporary checkpoint: deployment progress is awaiting validation.",
+                    "target": "memory",
+                    "memory_type": "episodic",
+                },
+            )
+        )
+        with provider._lock:
+            row = provider._require_conn().execute(
+                "SELECT json_extract(metadata, '$.lifecycle') FROM memories WHERE id = ?",
+                (payload["id"],),
+            ).fetchone()
+    finally:
+        provider.shutdown()
+
+    assert row[0] == "candidate"
+    assert payload["lifecycle"] == "candidate"
+    assert payload["receipt"]["action"] == "candidate"
+
+
 def test_curated_memory_default_is_not_injected_for_explicit_gateway_user(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     store = MemoryStore()

--- a/tests/test_nightly_llm.py
+++ b/tests/test_nightly_llm.py
@@ -138,6 +138,38 @@ def test_nightly_llm_retry_reports_actual_attempt_count_for_non_retryable_errors
     assert "auth after 3 attempt(s)" not in message
 
 
+def test_nightly_llm_retry_treats_http_404_as_non_retryable_endpoint_config(monkeypatch):
+    import scope_recall.nightly_llm as nightly_llm
+
+    calls = {"count": 0}
+
+    def fake_call_llm(*args, **kwargs):  # noqa: ARG001
+        calls["count"] += 1
+        raise RuntimeError("LLM HTTP 404 at https://example.invalid/responses")
+
+    monkeypatch.setattr(nightly_llm, "call_llm", fake_call_llm)
+
+    try:
+        nightly_llm.call_llm_with_retries(
+            "prompt",
+            model="test-model",
+            base_url="https://example.invalid",
+            api_key="",
+            timeout=1,
+            api_mode="codex_responses",
+            max_attempts=3,
+            retry_delay=0,
+        )
+    except RuntimeError as exc:
+        message = str(exc)
+    else:  # pragma: no cover - defensive, fake_call_llm always raises
+        raise AssertionError("call_llm_with_retries should raise after endpoint error")
+
+    assert calls["count"] == 1
+    assert "endpoint_config after 1 attempt(s)" in message
+    assert "after 3 attempt(s)" not in message
+
+
 def test_nightly_llm_resolve_config_accepts_digest_options_shape(tmp_path):
     from scope_recall.nightly_llm import resolve_llm_config
 
@@ -256,3 +288,29 @@ model:
     assert config["api_mode"] == "codex_responses"
     assert config["api_key"] == "codex-oauth-token"
     assert config["api_key"] != "deepseek-should-not-be-used"
+
+
+def test_nightly_llm_default_codex_uses_official_backend_without_explicit_base_url(tmp_path):
+    from scope_recall.nightly_llm import resolve_llm_config
+
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    (hermes_home / "auth.json").write_text(
+        json.dumps({"credential_pool": {"openai-codex": [{"access_token": "codex-oauth-token"}]}}),
+        encoding="utf-8",
+    )
+    (hermes_home / "config.yaml").write_text(
+        """
+model:
+  provider: openai-codex
+  default: gpt-5.5
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    config = resolve_llm_config(hermes_home, DigestOptions(hermes_home=hermes_home, digest_date=date(2026, 6, 13)))
+
+    assert config["provider"] == "openai-codex"
+    assert config["api_mode"] == "codex_responses"
+    assert config["base_url"] == "https://chatgpt.com/backend-api/codex"

--- a/tests/test_prompting.py
+++ b/tests/test_prompting.py
@@ -15,8 +15,16 @@ from scope_recall.provider import ScopeRecallMemoryProvider
 class _RecallService:
     def __init__(self, items: list[RecallItem]) -> None:
         self._items = items
+        self.include_curated: bool | None = None
 
-    def search_memories(self, _query: str, *, limit: int) -> list[RecallItem]:
+    def search_memories(
+        self,
+        _query: str,
+        *,
+        limit: int,
+        include_curated: bool = True,
+    ) -> list[RecallItem]:
+        self.include_curated = include_curated
         return self._items[:limit]
 
 
@@ -109,6 +117,71 @@ def test_prompt_rendering_redacts_legacy_secret_like_summary() -> None:
 
     assert secret not in rendered
     assert "[REDACTED_SECRET]" in rendered
+
+
+def test_prompt_auto_recall_can_exclude_curated_rows_without_disabling_sqlite_recall() -> None:
+    curated = RecallItem(
+        id="curated:user:1",
+        content="User prefers concise reports.",
+        summary="User prefers concise reports.",
+        source="builtin-curated",
+        target="user",
+        score=0.99,
+        updated_at="2026-08-05T00:00:00+00:00",
+        metadata={},
+    )
+    dynamic = RecallItem(
+        id="dynamic-1",
+        content="The active project uses pytest.",
+        summary="The active project uses pytest.",
+        source="tool-store",
+        target="project",
+        score=0.90,
+        updated_at="2026-08-05T00:00:00+00:00",
+        metadata={},
+    )
+    provider = _Provider([dynamic])
+    provider._config["curated_memory"] = {
+        "mode": "profile-global",
+        "auto_recall": False,
+        "include_in_tools": True,
+    }
+
+    rendered = render_current_turn_recall(
+        provider,
+        "Please recall the current project test configuration.",
+    )
+
+    assert provider._recall_service.include_curated is False
+    assert "The active project uses pytest." in rendered
+    assert curated.summary not in rendered
+
+
+def test_prompt_auto_recall_keeps_curated_rows_when_explicitly_enabled() -> None:
+    curated = RecallItem(
+        id="curated:user:1",
+        content="User prefers concise reports.",
+        summary="User prefers concise reports.",
+        source="builtin-curated",
+        target="user",
+        score=0.99,
+        updated_at="2026-08-05T00:00:00+00:00",
+        metadata={},
+    )
+    provider = _Provider([curated])
+    provider._config["curated_memory"] = {
+        "mode": "profile-global",
+        "auto_recall": True,
+        "include_in_tools": True,
+    }
+
+    rendered = render_current_turn_recall(
+        provider,
+        "Please recall the user's report preference.",
+    )
+
+    assert provider._recall_service.include_curated is True
+    assert "User prefers concise reports." in rendered
 
 
 def test_prefetch_recall_failure_is_fail_soft(

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -1689,6 +1689,41 @@ def test_builtin_memory_write_round_trips_into_current_turn_recall(provider, mon
     assert "problem-first" in result.lower()
 
 
+def test_promoted_unique_identifier_exact_hit_is_top_one(provider):
+    marker = "ORION-VERIFICATION-104100-C9F4"
+    stored = json.loads(
+        provider.handle_tool_call(
+            "scope_recall_store",
+            {
+                "content": f"Orion Ledger reference {marker} has status green.",
+                "target": "memory",
+                "memory_type": "factual",
+                "importance": 0.4,
+                "entities": [marker, "Orion Ledger"],
+            },
+        )
+    )
+    assert stored["stored"] is True
+
+    with provider._lock:
+        row = provider._require_conn().execute(
+            "SELECT metadata FROM memories WHERE id = ?",
+            (stored["id"],),
+        ).fetchone()
+    metadata = json.loads(row["metadata"])
+    assert metadata["lifecycle"] == "promoted"
+    assert marker.lower() in metadata["entities"]
+
+    searched = json.loads(
+        provider.handle_tool_call(
+            "scope_recall_search",
+            {"query": marker, "limit": 20, "include_trace": True},
+        )
+    )
+
+    assert searched["results"][0]["id"] == stored["id"]
+
+
 def test_short_or_greeting_query_is_gated(provider):
     payload = json.loads(
         provider.handle_tool_call("scope_recall_store", {"content": "Joy prefers concise answers.", "target": "user"})

--- a/tests/test_retrieval_policy.py
+++ b/tests/test_retrieval_policy.py
@@ -266,6 +266,70 @@ def test_generic_chinese_system_question_keeps_strong_semantic_hit():
     assert service.last_funnel_trace["filters"]["entity_scope_mismatch"] == 0
 
 
+def test_answer_bearing_curated_fact_outranks_adjacent_preference():
+    query = "用户的笔记本型号是什么"
+    browser_preference = RecallItem(
+        id="browser-preference",
+        content="用户的幻X 2023笔记本以Chrome为主浏览器，并关注同步稳定性。",
+        summary="笔记本浏览器偏好",
+        source="builtin-curated",
+        target="user",
+        score=0.0,
+        updated_at="2026-08-01T00:00:00+00:00",
+        metadata={
+            "lexical_score": lexical_score(
+                query=query,
+                content="用户的幻X 2023笔记本以Chrome为主浏览器，并关注同步稳定性。",
+                summary="笔记本浏览器偏好",
+                source="builtin-curated",
+                target="user",
+            ),
+            "vector_score": 0.0,
+            "scope_id": "shared-scope",
+            "memory_type": "preference",
+            "trust": 0.92,
+            "importance": 0.86,
+        },
+    )
+    model_fact = RecallItem(
+        id="device-model",
+        content="用户的笔记本是ROG Flow Z13幻X 2023（GZ301VV）。",
+        summary="用户的笔记本是ROG Flow Z13幻X 2023（GZ301VV）。",
+        source="builtin-curated",
+        target="memory",
+        score=0.0,
+        updated_at="2026-08-01T00:00:00+00:00",
+        metadata={
+            "lexical_score": lexical_score(
+                query=query,
+                content="用户的笔记本是ROG Flow Z13幻X 2023（GZ301VV）。",
+                summary="用户的笔记本是ROG Flow Z13幻X 2023（GZ301VV）。",
+                source="builtin-curated",
+                target="memory",
+            ),
+            "vector_score": 0.0,
+            "scope_id": "shared-scope",
+            "memory_type": "factual",
+            "trust": 0.92,
+            "importance": 0.68,
+        },
+    )
+    provider = DummyProvider(
+        {
+            "mode": "hybrid",
+            "include_general": "same-scope",
+            "entity_scope_filter_enabled": True,
+            "min_score": 0.18,
+        },
+        db_items=[],
+        curated_items=[browser_preference, model_fact],
+    )
+
+    results = RecallService(provider).search_memories(query, limit=2)
+
+    assert [item.id for item in results] == ["device-model", "browser-preference"]
+
+
 def test_chinese_location_question_drops_interrogative_fragments():
     assert semantic_query_tokens("玉衡在哪") == ["玉衡"]
     assert semantic_query_tokens("开阳星在哪") == ["开阳星"]

--- a/tooling.py
+++ b/tooling.py
@@ -327,8 +327,9 @@ class ScopeRecallToolService:
             relation_sync_status = "completed"
         else:
             relation_sync_status = "not_run"
+        lifecycle = self._stored_lifecycle(memory_id) if inserted else ""
         receipt = self._receipt(
-            "promoted" if inserted else outcome,
+            lifecycle or ("promoted" if inserted else outcome),
             target=target,
             id=memory_id,
             scope_mode=scope_mode,
@@ -346,12 +347,38 @@ class ScopeRecallToolService:
                 "id": memory_id,
                 "target": target,
                 "scope_mode": scope_mode,
+                "lifecycle": lifecycle,
                 "relation_sync_status": relation_sync_status,
                 "recovered": recovered,
                 "retry_count": retry_count,
                 "receipt": receipt,
             }
         )
+
+    def _stored_lifecycle(self, memory_id: str) -> str:
+        """Project the committed lifecycle into the public store receipt.
+
+        Receipt projection is best-effort: a successful store must not be
+        turned into a failed tool call merely because this read-side lookup
+        is unavailable during connection recovery.
+        """
+
+        if not memory_id:
+            return ""
+        try:
+            with self.provider._lock:
+                row = self.provider._require_conn().execute(
+                    "SELECT json_extract(metadata, '$.lifecycle') FROM memories WHERE id = ?",
+                    (memory_id,),
+                ).fetchone()
+        except Exception:
+            logger.warning(
+                "Scope Recall could not project lifecycle for store receipt %s",
+                memory_id,
+                exc_info=True,
+            )
+            return ""
+        return str(row[0] or "").strip().lower() if row is not None else ""
 
     def _recoverable_store_error(self, exc: Exception) -> bool:
         if not isinstance(exc, sqlite3.Error):


### PR DESCRIPTION
## Summary

Split curated-memory behavior into three independent controls and harden recall, retrieval, and operator diagnostics.

## Changes

### Curated memory deduplication (main feature)
- **`curated_memory.auto_recall`** (default `true`): when set to `false`, automatic current-turn recall excludes live `USER.md`/`MEMORY.md` rows — eliminating duplicate injection when Hermes already injects curated files natively.
- **`curated_memory.include_in_tools`** (default `true`): keeps curated rows available to explicit `scope_recall_profile`/`scope_recall_search` tools.
- **`curated_memory.dedupe_candidates`** (default `true`): rejects automatic event and journal candidates strictly covered by live curated authority, with an audit receipt; changed-value candidates are preserved.

Candidate paths covered: per-turn events (`store_event_candidates`) and journal digest (`apply_journal_candidates`), both guarded by `curated_memory_policy_allows` so scope/mode allow-lists stay authoritative.

### Retrieval & entities
- Chinese attribute queries (型号/版本/名称) now boost answer-bearing documents over adjacent preferences.
- Stable snake_case identifiers (`notebook_model`) remain indexable while tool-trace names stay filtered.

### Nightly digest
- `openai-codex` provider defaults to the official Codex backend URL.
- HTTP 404 classified as non-retryable endpoint config errors.

### Doctor & tooling
- Doctor fails hard when an enabled background digest's latest run failed.
- Doctor JSON is ASCII-safe for cp936 consoles.
- `scope_recall_store` receipts project the actual committed lifecycle.

## Tests
- 2247 passed, 6 skipped (full suite, `pytest -q`).
- New regression tests: `tests/test_curated_dedup.py`, `tests/test_doctor_output_encoding.py`, plus extended coverage for prompting, retrieval policy, entity quality, nightly LLM, provider, and governance contracts.