### PR TITLE
feat(capture_llm): support thinking parameter passthrough

### DIFF
--- a/capture_llm.py
+++ b/capture_llm.py
@@ -154,6 +154,7 @@ def extract_capture_candidates(
     )
     timeout = float(llm_config.get("timeout", 15.0))
     max_tokens = int(llm_config.get("max_tokens_per_turn", 2000))
+    thinking = llm_config.get("thinking")
 
     api_key = _resolve_api_key(llm_config)
     if not api_key:
@@ -196,6 +197,7 @@ def extract_capture_candidates(
             endpoint=endpoint,
             append_v1=append_v1,
             allow_insecure_endpoint=allow_insecure_endpoint,
+            thinking=thinking,
         )
     except UnsafeEndpointError:
         logger.warning(
@@ -258,6 +260,7 @@ def _call_openai_compatible(
     endpoint: str = "",
     append_v1: bool = True,
     allow_insecure_endpoint: bool = False,
+    thinking: Any = None,
 ) -> str:
     """Call an OpenAI-compatible chat completions endpoint."""
     url = chat_completions_endpoint(
@@ -266,13 +269,16 @@ def _call_openai_compatible(
         append_v1=append_v1,
         allow_insecure_endpoint=allow_insecure_endpoint,
     )
+    body_dict: dict[str, Any] = {
+        "model": model,
+        "messages": messages,
+        "max_tokens": max_tokens,
+        "temperature": 0.1,
+    }
+    if thinking is not None:
+        body_dict["thinking"] = thinking
     body = json.dumps(
-        {
-            "model": model,
-            "messages": messages,
-            "max_tokens": max_tokens,
-            "temperature": 0.1,
-        },
+        body_dict,
         ensure_ascii=False,
     ).encode("utf-8")
 


### PR DESCRIPTION
## Summary

`capture_llm.py`'s request payload was hardcoded to `model`/`messages`/`max_tokens`/`temperature`, with no way to pass a `thinking` parameter. Reasoning-heavy models that default to thinking mode (Qwen3.6, GLM-4.7-flash, DeepSeek, etc.) consume the completion budget on `reasoning_content`, which can cause empty `content` or truncated JSON (`finish_reason=length`) on extraction tasks.

This mirrors the existing fix in `nightly_llm.py` (issue #37) which already supports a `thinking` passthrough — but the same support was never added to `capture_llm.py`.

## What this PR does (optional passthrough, not a forced behavior change)

- Add `thinking: dict | None = None` parameter to `_call_openai_compatible()`
- Read `thinking` from `capture_llm` config in `extract_capture_candidates()`
- Inject `thinking` into the payload **only when set in config** — when `thinking` is `None` (default), the payload is byte-for-byte identical to before, so non-reasoning models and existing configs are completely unaffected

This is an **opt-in** capability: operators who use reasoning models with default thinking can choose to disable or tune it via config. Nothing changes unless configured.

## Example usage

```json
{
  "capture_llm": {
    "thinking": {"type": "disabled"}
  }
}
```

## Measured impact (Qwen3.6-Max, OpenAI-compatible endpoint)

| Config | Reasoning chunks | Content chunks | Wall time |
|--------|-----------------|----------------|-----------|
| default (thinking on) | 1230 | 54 | 44.8s |
| `thinking: {"type":"disabled"}` | 0 | 153 | 6.6s |

Disabling thinking for JSON-extraction tasks (which don't need it) makes capture ~7x faster and eliminates empty-content/truncation issues — but again, this is the operator's choice via config, not a default behavior change.

## Related

- Issue #37 (fixed `nightly_llm.py` but not `capture_llm.py`)