### PR TITLE
feat: release the cross-process writer lease after an idle window (#58)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to `scope-recall` will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Voluntary cross-process truth writer-lease idle release: after `writer_lease.idle_release_seconds` (default 1800, 0 disables) without user-turn activity, the writer process quiesces its capture writer, closes the write pager, releases the OS lease, and demotes itself to the read-only runtime. An active peer (e.g. Hermes Desktop) then promotes itself via the existing on-turn probe instead of starving behind a resident idle process (e.g. a messaging gateway). The lease still guarantees exactly one writer at any moment; only the hold-until-exit starvation is removed. (#58)
+
 ## [1.10.5] - 2026-08-25
 
 This patch candidate is cumulative since the last public release, `1.10.3`, and supersedes the unpublished `1.10.4` source checkpoint. It closes the remaining bounded-concurrency, release-provenance, and distribution-scanner defects found by exact-epoch review while retaining the issue #50 contract, without changing SQLite authority or stable provider/tool identities.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to `scope-recall` will be documented in this file.
 ## [Unreleased]
 
 ### Added
-- Voluntary cross-process truth writer-lease idle release: after `writer_lease.idle_release_seconds` (default 1800, 0 disables) without user-turn activity, the writer process quiesces its capture writer, closes the write pager, releases the OS lease, and demotes itself to the read-only runtime. An active peer (e.g. Hermes Desktop) then promotes itself via the existing on-turn probe instead of starving behind a resident idle process (e.g. a messaging gateway). The lease still guarantees exactly one writer at any moment; only the hold-until-exit starvation is removed. (#58)
+- Voluntary cross-process truth writer-lease idle release (opt-in): after `writer_lease.idle_release_seconds` (default 0 = disabled; set e.g. 1800 to enable) without user-turn activity, the writer process quiesces its capture writer, closes the write pager, releases the OS lease, and demotes itself to the read-only runtime. An active peer (e.g. Hermes Desktop) then promotes itself via the existing on-turn probe instead of starving behind a resident idle process (e.g. a messaging gateway). The lease still guarantees exactly one writer at any moment; only the hold-until-exit starvation is removed. Background digest activity and queued/in-flight writes veto the release. (#58)
 
 ## [1.10.5] - 2026-08-25
 

--- a/_internal/runtime/process_lifecycle.py
+++ b/_internal/runtime/process_lifecycle.py
@@ -767,6 +767,163 @@ def _promote_under_lifecycle_lock(provider: Any) -> None:
         _call_provider(provider, "_initialize_read_only_runtime", default=lambda: initialize_read_only_runtime(provider))
 
 
+DEFAULT_IDLE_WRITER_LEASE_SECONDS = 1800.0
+MAX_IDLE_WRITER_LEASE_SECONDS = 86400.0
+
+
+def idle_writer_lease_release_seconds(provider: Any) -> float:
+    """Configured idle window in seconds; 0 disables voluntary release."""
+
+    raw = getattr(provider, "_config", None)
+    section = raw.get("writer_lease") if isinstance(raw, dict) else None
+    if not isinstance(section, dict):
+        section = {}
+    try:
+        value = float(
+            section.get("idle_release_seconds", DEFAULT_IDLE_WRITER_LEASE_SECONDS)
+        )
+    except (TypeError, ValueError):
+        value = DEFAULT_IDLE_WRITER_LEASE_SECONDS
+    return max(0.0, min(value, MAX_IDLE_WRITER_LEASE_SECONDS))
+
+
+def note_writer_activity(provider: Any) -> None:
+    """Record user-turn activity; the idle-release clock restarts per turn."""
+
+    provider._last_writer_activity = time.monotonic()
+
+
+def maybe_idle_release_writer_lease(provider: Any) -> None:
+    """Demote an idle writer to a read-only peer so an active process can write.
+
+    Called from the capture writer loop's idle path. The cross-process truth
+    writer lease is otherwise held for the process lifetime, so a resident
+    but idle process (e.g. a messaging gateway with no active chats) starves
+    the user's interactive surface indefinitely. After
+    ``writer_lease.idle_release_seconds`` without a user turn this process
+    voluntarily demotes itself; the existing on-turn promotion probe lets
+    whichever process actually has activity take the lease next.
+    """
+
+    if getattr(provider, "_truth_writer_role", None) != "owner":
+        return
+    idle_seconds = idle_writer_lease_release_seconds(provider)
+    if idle_seconds <= 0:
+        return
+    if getattr(provider, "_idle_release_in_progress", False):
+        return
+    last_activity = float(getattr(provider, "_last_writer_activity", 0.0) or 0.0)
+    if last_activity <= 0:
+        return
+    if time.monotonic() - last_activity < idle_seconds:
+        return
+    provider._idle_release_in_progress = True
+    threading.Thread(
+        target=_demote_idle_writer_guarded,
+        args=(provider, idle_seconds),
+        daemon=True,
+        name="scope-recall-idle-release",
+    ).start()
+
+
+def _demote_idle_writer_guarded(provider: Any, idle_seconds: float) -> None:
+    try:
+        demote_writer_to_reader(provider, idle_seconds=idle_seconds)
+    except Exception:
+        logger.exception("Scope Recall idle writer-lease release failed")
+    finally:
+        provider._idle_release_in_progress = False
+
+
+def demote_writer_to_reader(provider: Any, *, idle_seconds: float) -> bool:
+    """Release the writer lease after a sustained idle window.
+
+    Mirror of :func:`promote_reader_to_writer`: quiesce the capture writer,
+    close the write pager, release the OS lease, then reopen as the read-only
+    runtime. Returns True when this runtime ends as a reader (or already was
+    one). Any consistency failure keeps the writer role intact so a later
+    idle tick can retry.
+    """
+
+    if getattr(provider, "_truth_writer_role", None) != "owner":
+        return True
+    lease = getattr(provider, "_truth_writer_lease", None)
+    if lease is None:
+        return False
+    # Re-check idleness before touching anything: a turn that started while
+    # the demote thread was spawning must win over this release.
+    last_activity = float(getattr(provider, "_last_writer_activity", 0.0) or 0.0)
+    if time.monotonic() - last_activity < idle_seconds:
+        return False
+    if int(getattr(provider, "_foreground_busy_count", 0) or 0) > 0:
+        return False
+    quiesce = _module_attr(provider, "quiesce_writer_for_lease_release", None)
+    if not callable(quiesce):
+        from ...capture import quiesce_writer_for_lease_release as quiesce
+    if not quiesce(provider):
+        return False
+    lifecycle_lock = getattr(provider, "_writer_lifecycle_lock", None)
+    if lifecycle_lock is None:
+        return False
+    with lifecycle_lock:
+        # Final role/lease re-check under the lifecycle lock.
+        if getattr(provider, "_truth_writer_role", None) != "owner":
+            return True
+        lease = getattr(provider, "_truth_writer_lease", None)
+        if lease is None:
+            return False
+        conn = getattr(provider, "_conn", None)
+        if conn is not None:
+            try:
+                _call_provider(
+                    provider,
+                    "_close_published_connection",
+                    conn,
+                    context="idle writer-lease release",
+                )
+            except Exception:
+                logger.exception(
+                    "Scope Recall idle release could not close the writer "
+                    "connection; restoring the writer runtime"
+                )
+                try:
+                    _call_provider(
+                        provider,
+                        "_initialize_writer_runtime",
+                        default=lambda: initialize_writer_runtime(provider),
+                    )
+                except Exception:
+                    logger.exception(
+                        "Scope Recall writer runtime restore after failed "
+                        "idle release failed"
+                    )
+                return False
+            provider._conn = None
+        try:
+            lease.release()
+        except Exception:
+            # The OS lease then leaks until process exit, where the kernel
+            # reclaims it. This runtime still becomes a reader so it stops
+            # writing; peers can take over once this process exits.
+            logger.exception(
+                "Scope Recall idle release could not release the OS lease"
+            )
+        provider._truth_writer_lease = None
+        provider._truth_writer_role = "reader"
+        provider._truth_writer_owner = {}
+        _call_provider(
+            provider,
+            "_initialize_read_only_runtime",
+            default=lambda: initialize_read_only_runtime(provider),
+        )
+        logger.info(
+            "Scope Recall released the truth writer lease after %.0f idle "
+            "seconds; continuing as a read-only recall peer",
+            idle_seconds,
+        )
+        return True
+
+
 def shutdown_provider_process(provider: Any, *, timeout: float = 3.0) -> None:
     """Quiesce writer and digest work, then close shared resources.
 

--- a/_internal/runtime/process_lifecycle.py
+++ b/_internal/runtime/process_lifecycle.py
@@ -767,7 +767,7 @@ def _promote_under_lifecycle_lock(provider: Any) -> None:
         _call_provider(provider, "_initialize_read_only_runtime", default=lambda: initialize_read_only_runtime(provider))
 
 
-DEFAULT_IDLE_WRITER_LEASE_SECONDS = 1800.0
+DEFAULT_IDLE_WRITER_LEASE_SECONDS = 0.0
 MAX_IDLE_WRITER_LEASE_SECONDS = 86400.0
 
 
@@ -856,6 +856,13 @@ def demote_writer_to_reader(provider: Any, *, idle_seconds: float) -> bool:
     if time.monotonic() - last_activity < idle_seconds:
         return False
     if int(getattr(provider, "_foreground_busy_count", 0) or 0) > 0:
+        return False
+    # A running background digest holds its own write work; releasing the
+    # lease under it would strand its connection mid-transaction.
+    background_fn = getattr(provider, "_background_work", None)
+    work = background_fn() if callable(background_fn) else None
+    digest_thread = getattr(work, "thread", None) if work is not None else None
+    if digest_thread is not None and digest_thread.is_alive():
         return False
     quiesce = _module_attr(provider, "quiesce_writer_for_lease_release", None)
     if not callable(quiesce):

--- a/capture.py
+++ b/capture.py
@@ -231,6 +231,21 @@ def _drain_relation_rebuild_debt_locked(provider: Any) -> None:
         logger.warning("Scope Recall relation rebuild chunk failed: %s", result)
 
 
+IDLE_LEASE_CHECK_INTERVAL_SECONDS = 5.0
+
+
+def _idle_release_probe() -> Any:
+    """Late-bind the idle-release probe; process_lifecycle imports capture."""
+
+    try:
+        from ._internal.runtime.process_lifecycle import (
+            maybe_idle_release_writer_lease,
+        )
+    except Exception:
+        return None
+    return maybe_idle_release_writer_lease
+
+
 def start_writer(provider: Any) -> None:
     """Start the sole consumer after binding the configured finite queue."""
 
@@ -243,6 +258,7 @@ def start_writer(provider: Any) -> None:
             if shutdown_requested is not None:
                 shutdown_requested.clear()
             provider._stop.clear()
+            provider._last_writer_activity = time.monotonic()
             maintenance_stop = getattr(provider, "_maintenance_stop", None)
             if maintenance_stop is not None:
                 maintenance_stop.clear()
@@ -296,6 +312,17 @@ def writer_loop(provider: Any) -> None:
                     if callable(rollback):
                         rollback("capture writer maintenance")
                     logger.exception("Scope Recall writer maintenance failed")
+            last_lease_check = float(
+                getattr(provider, "_last_idle_lease_check", 0.0) or 0.0
+            )
+            if now - last_lease_check >= IDLE_LEASE_CHECK_INTERVAL_SECONDS:
+                provider._last_idle_lease_check = now
+                try:
+                    maybe_idle_release = _idle_release_probe()
+                    if maybe_idle_release is not None:
+                        maybe_idle_release(provider)
+                except Exception:
+                    logger.exception("Scope Recall idle writer-lease check failed")
             continue
 
         processing_store = False
@@ -463,6 +490,44 @@ def shutdown_writer(provider: Any, timeout: float = 3.0) -> None:
     if not provider._write_queue.empty():
         raise RuntimeError("Scope Recall writer stopped with unconsumed queue control")
     provider._writer_thread = None
+
+
+def quiesce_writer_for_lease_release(provider: Any, *, timeout: float = 5.0) -> bool:
+    """Stop the writer loop for a voluntary idle lease release.
+
+    Unlike :func:`shutdown_writer` this never sets ``_shutdown_requested`` —
+    the runtime must stay promotable so the next user turn (here or in a
+    peer process) can take the lease back. Returns False and leaves the
+    writer untouched when queued or in-flight writes exist, or when the loop
+    does not stop before the deadline.
+    """
+
+    thread = getattr(provider, "_writer_thread", None)
+    if thread is None or not thread.is_alive():
+        provider._writer_thread = None
+        return True
+    work_queue = getattr(provider, "_write_queue", None)
+    deadline = time.monotonic() + max(0.0, float(timeout))
+    with _provider_lock_until(provider, "_capture_submission_lock", deadline):
+        if work_queue is not None and not work_queue.empty():
+            return False
+        if int(getattr(provider, "_capture_queue_processing", 0) or 0) > 0:
+            return False
+        try:
+            accepted = put_work(
+                work_queue,
+                None,
+                timeout=min(CONTROL_PUT_TIMEOUT_SECONDS, _remaining(deadline)),
+            )
+        except RuntimeError:
+            return False
+        if not accepted:
+            return False
+    thread.join(timeout=_remaining(deadline))
+    if thread.is_alive():
+        return False
+    provider._writer_thread = None
+    return True
 
 
 @contextmanager

--- a/config.json
+++ b/config.json
@@ -2,7 +2,7 @@
   "auto_recall": true,
   "auto_capture": true,
   "writer_lease": {
-    "idle_release_seconds": 1800
+    "idle_release_seconds": 0
   },
   "memory_isolated_chat_ids": [],
   "auto_recall_min_length": 15,

--- a/config.json
+++ b/config.json
@@ -1,6 +1,9 @@
 {
   "auto_recall": true,
   "auto_capture": true,
+  "writer_lease": {
+    "idle_release_seconds": 1800
+  },
   "memory_isolated_chat_ids": [],
   "auto_recall_min_length": 15,
   "auto_recall_min_repeated": 8,

--- a/config.py
+++ b/config.py
@@ -17,7 +17,7 @@ DEFAULT_CONFIG: dict[str, Any] = {
     "auto_recall": True,
     "auto_capture": True,
     "writer_lease": {
-        "idle_release_seconds": 1800,
+        "idle_release_seconds": 0,
     },
     "memory_isolated_chat_ids": [],
     "auto_recall_min_length": 15,

--- a/config.py
+++ b/config.py
@@ -16,6 +16,9 @@ _CONFIG_LOAD_ERRORS_KEY = "_config_load_errors"
 DEFAULT_CONFIG: dict[str, Any] = {
     "auto_recall": True,
     "auto_capture": True,
+    "writer_lease": {
+        "idle_release_seconds": 1800,
+    },
     "memory_isolated_chat_ids": [],
     "auto_recall_min_length": 15,
     "auto_recall_min_repeated": 8,

--- a/config_schema.py
+++ b/config_schema.py
@@ -11,7 +11,7 @@ from typing import Any
 _DESCRIPTION_OVERRIDES = {
     "auto_recall": "Enable automatic recall injection at turn start.",
     "auto_capture": "Capture eligible conversation turns into Scope Recall.",
-    "writer_lease.idle_release_seconds": "Seconds without user-turn activity before the truth-writer process voluntarily releases the cross-process writer lease and demotes itself to a read-only peer, so an active peer (e.g. Hermes Desktop) can take over via the existing promotion probe instead of starving behind a resident idle process. 0 disables the release.",
+    "writer_lease.idle_release_seconds": "Seconds without user-turn activity before the truth-writer process voluntarily releases the cross-process writer lease and demotes itself to a read-only peer, so an active peer (e.g. Hermes Desktop) can take over via the existing promotion probe instead of starving behind a resident idle process. Default 0 disables the release; set e.g. 1800 to opt in.",
     "capture_queue_capacity": "Maximum sanitized capture jobs held in the bounded process-local writer queue. Excess enqueue attempts receive an explicit rejected or deferred status instead of silent loss; queued payloads are not persisted.",
     "automatic_digest_default_lifecycle": "Lifecycle for non-time-sensitive journal/nightly automatic digest outputs. Candidate is the review-first default; promoted explicitly opts into immediate recall visibility. Time-sensitive snapshots remain candidates that need a live check.",
     "memory_isolated_chat_ids": "Runtime-only chat identifiers excluded from prompt recall, tools, capture, journal, and digest surfaces.",

--- a/config_schema.py
+++ b/config_schema.py
@@ -11,6 +11,7 @@ from typing import Any
 _DESCRIPTION_OVERRIDES = {
     "auto_recall": "Enable automatic recall injection at turn start.",
     "auto_capture": "Capture eligible conversation turns into Scope Recall.",
+    "writer_lease.idle_release_seconds": "Seconds without user-turn activity before the truth-writer process voluntarily releases the cross-process writer lease and demotes itself to a read-only peer, so an active peer (e.g. Hermes Desktop) can take over via the existing promotion probe instead of starving behind a resident idle process. 0 disables the release.",
     "capture_queue_capacity": "Maximum sanitized capture jobs held in the bounded process-local writer queue. Excess enqueue attempts receive an explicit rejected or deferred status instead of silent loss; queued payloads are not persisted.",
     "automatic_digest_default_lifecycle": "Lifecycle for non-time-sensitive journal/nightly automatic digest outputs. Candidate is the review-first default; promoted explicitly opts into immediate recall visibility. Time-sensitive snapshots remain candidates that need a live check.",
     "memory_isolated_chat_ids": "Runtime-only chat identifiers excluded from prompt recall, tools, capture, journal, and digest surfaces.",

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -378,3 +378,6 @@ Treat chat aliases as explicit operator access-control grants.
 - `vector.table_name` (string; risk: `medium`; restart_required: `yes`) — Scope Recall configuration key `vector.table_name` in the `vector` group. Default: `"memories"`
 - `vector.top_k` (integer; risk: `medium`; restart_required: `yes`) — Scope Recall configuration key `vector.top_k` in the `vector` group. Default: `8`
 - `vector.write_outbox_replay_limit` (integer; risk: `medium`; restart_required: `yes`) — Maximum durable vector outbox events replayed after one committed memory write so transient backlog converges during normal traffic. Default: `20`
+## `writer_lease`
+
+- `writer_lease.idle_release_seconds` (integer; risk: `low`; restart_required: `no`) — Seconds without user-turn activity before the truth-writer process voluntarily releases the cross-process writer lease and demotes itself to a read-only peer, so an active peer (e.g. Hermes Desktop) can take over via the existing promotion probe instead of starving behind a resident idle process. 0 disables the release. Default: `1800`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -380,4 +380,4 @@ Treat chat aliases as explicit operator access-control grants.
 - `vector.write_outbox_replay_limit` (integer; risk: `medium`; restart_required: `yes`) — Maximum durable vector outbox events replayed after one committed memory write so transient backlog converges during normal traffic. Default: `20`
 ## `writer_lease`
 
-- `writer_lease.idle_release_seconds` (integer; risk: `low`; restart_required: `no`) — Seconds without user-turn activity before the truth-writer process voluntarily releases the cross-process writer lease and demotes itself to a read-only peer, so an active peer (e.g. Hermes Desktop) can take over via the existing promotion probe instead of starving behind a resident idle process. 0 disables the release. Default: `1800`
+- `writer_lease.idle_release_seconds` (integer; risk: `low`; restart_required: `no`) — Seconds without user-turn activity before the truth-writer process voluntarily releases the cross-process writer lease and demotes itself to a read-only peer, so an active peer (e.g. Hermes Desktop) can take over via the existing promotion probe instead of starving behind a resident idle process. Set e.g. `1800` to opt in. Default: `0`

--- a/provider.py
+++ b/provider.py
@@ -9,6 +9,7 @@ import os
 import queue
 import sqlite3
 import threading
+import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -407,6 +408,7 @@ class ScopeRecallMemoryProvider(MemoryProvider):
     def on_turn_start(self, turn_number: int, message: str, **kwargs) -> None:
         del message, kwargs
         self._current_turn = int(turn_number or 0)
+        self._last_writer_activity = time.monotonic()
         if self._truth_writes_blocked():
             self._maybe_promote_to_writer()
             return

--- a/tests/test_writer_lease_idle_release.py
+++ b/tests/test_writer_lease_idle_release.py
@@ -1,0 +1,220 @@
+"""Idle writer-lease release (#58).
+
+A writer with no user-turn activity beyond ``writer_lease.idle_release_seconds``
+voluntarily quiesces its capture writer, closes the write pager, releases the
+cross-process OS lease, and demotes itself to the read-only runtime so an
+active peer can take over via the existing on-turn promotion probe. Recent
+activity suppresses the release, ``0`` disables it, and a later turn
+re-promotes the runtime. The release must be real at the OS level: a separate
+process must acquire the lease afterwards.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+import subprocess
+import sys
+import textwrap
+import time
+from pathlib import Path
+
+import pytest
+
+from plugin_source import assert_same_source
+from plugins.memory import load_memory_provider
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_WORKSPACE_PROVIDER = (_REPO_ROOT / "provider.py").resolve()
+
+
+def _write_config(hermes_home: Path, payload: dict) -> None:
+    path = hermes_home / "scope-recall" / "config.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _provider():
+    provider = load_memory_provider("scope-recall")
+    module = inspect.getmodule(type(provider))
+    assert module is not None
+    assert_same_source(
+        Path(module.__file__), _WORKSPACE_PROVIDER, label="runtime provider"
+    )
+    return provider
+
+
+def _initialize(provider, hermes_home: Path, session: str) -> None:
+    provider.initialize(
+        session,
+        hermes_home=str(hermes_home),
+        platform="cli",
+        user_id="lease-user",
+        chat_id="lease-chat",
+        agent_identity="tester",
+        agent_workspace="hermes",
+        agent_context="primary",
+    )
+
+
+def _lifecycle_module(provider):
+    """Resolve the process_lifecycle module bound to this provider's namespace."""
+
+    module = inspect.getmodule(type(provider))
+    assert module is not None
+    name = f"{module.__name__.rsplit('.', 1)[0]}._internal.runtime.process_lifecycle"
+    lifecycle = sys.modules.get(name)
+    if lifecycle is None:
+        lifecycle = __import__(name, fromlist=["demote_writer_to_reader"])
+    return lifecycle
+
+
+def _child_acquire_status(storage_dir: Path) -> str:
+    """Ask a separate process whether it can take the writer lease."""
+
+    child_script = textwrap.dedent(
+        f"""
+        import sys
+        from pathlib import Path
+        sys.path.insert(0, {str(_REPO_ROOT)!r})
+        from writer_lease import TruthWriterLease
+        lease = TruthWriterLease(Path({str(storage_dir)!r}), role="probe")
+        result = lease.acquire()
+        print("STATUS:" + result["status"], flush=True)
+        if result["status"] == "acquired":
+            lease.release()
+        """
+    )
+    child = subprocess.Popen(
+        [sys.executable, "-c", child_script],
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        line = (child.stdout.readline() or "").strip()
+        child.wait(timeout=10)
+        return line
+    finally:
+        if child.poll() is None:
+            child.kill()
+            child.wait(timeout=10)
+
+
+def _wait_for(predicate, timeout: float = 15.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.05)
+    return False
+
+
+def _shutdown(provider) -> None:
+    try:
+        provider.shutdown(timeout=5.0)
+    except Exception:
+        pass
+
+
+def test_idle_writer_voluntarily_releases_lease_and_demotes(tmp_path: Path) -> None:
+    _write_config(
+        tmp_path,
+        {"vector": {"enabled": False}, "writer_lease": {"idle_release_seconds": 1}},
+    )
+    provider = _provider()
+    _initialize(provider, tmp_path, "idle-release")
+    try:
+        assert provider._truth_writer_role == "owner"
+        lifecycle = _lifecycle_module(provider)
+        assert provider.flush(timeout=5.0)
+        provider._last_writer_activity = time.monotonic() - 10.0
+        lifecycle.maybe_idle_release_writer_lease(provider)
+        assert _wait_for(
+            lambda: not getattr(provider, "_idle_release_in_progress", False)
+        ), "idle-release thread did not finish"
+        assert provider._truth_writer_role == "reader"
+        assert provider._truth_writer_lease is None
+        # The release must be real at the OS level, not just role bookkeeping.
+        assert _child_acquire_status(tmp_path / "scope-recall") == "STATUS:acquired"
+    finally:
+        _shutdown(provider)
+
+
+def test_recent_activity_suppresses_idle_release(tmp_path: Path) -> None:
+    _write_config(
+        tmp_path,
+        {"vector": {"enabled": False}, "writer_lease": {"idle_release_seconds": 60}},
+    )
+    provider = _provider()
+    _initialize(provider, tmp_path, "idle-suppressed")
+    try:
+        assert provider._truth_writer_role == "owner"
+        lifecycle = _lifecycle_module(provider)
+        provider.on_turn_start(1, "hello")
+        lifecycle.maybe_idle_release_writer_lease(provider)
+        assert not getattr(provider, "_idle_release_in_progress", False)
+        time.sleep(0.2)
+        assert provider._truth_writer_role == "owner"
+        assert _child_acquire_status(tmp_path / "scope-recall") == "STATUS:busy"
+    finally:
+        _shutdown(provider)
+
+
+def test_zero_idle_release_disables_the_probe(tmp_path: Path) -> None:
+    _write_config(
+        tmp_path,
+        {"vector": {"enabled": False}, "writer_lease": {"idle_release_seconds": 0}},
+    )
+    provider = _provider()
+    _initialize(provider, tmp_path, "idle-disabled")
+    try:
+        assert provider._truth_writer_role == "owner"
+        lifecycle = _lifecycle_module(provider)
+        provider._last_writer_activity = time.monotonic() - 100000.0
+        lifecycle.maybe_idle_release_writer_lease(provider)
+        assert not getattr(provider, "_idle_release_in_progress", False)
+        time.sleep(0.2)
+        assert provider._truth_writer_role == "owner"
+        assert _child_acquire_status(tmp_path / "scope-recall") == "STATUS:busy"
+    finally:
+        _shutdown(provider)
+
+
+def test_demote_refuses_while_foreground_busy(tmp_path: Path) -> None:
+    _write_config(tmp_path, {"vector": {"enabled": False}})
+    provider = _provider()
+    _initialize(provider, tmp_path, "busy-guard")
+    try:
+        assert provider._truth_writer_role == "owner"
+        lifecycle = _lifecycle_module(provider)
+        provider._last_writer_activity = time.monotonic() - 100000.0
+        provider._foreground_busy_count = 1
+        try:
+            assert (
+                lifecycle.demote_writer_to_reader(provider, idle_seconds=1.0) is False
+            )
+            assert provider._truth_writer_role == "owner"
+        finally:
+            provider._foreground_busy_count = 0
+    finally:
+        _shutdown(provider)
+
+
+def test_demoted_runtime_re_promotes_on_next_turn(tmp_path: Path) -> None:
+    _write_config(tmp_path, {"vector": {"enabled": False}})
+    provider = _provider()
+    _initialize(provider, tmp_path, "re-promote")
+    try:
+        assert provider._truth_writer_role == "owner"
+        lifecycle = _lifecycle_module(provider)
+        assert provider.flush(timeout=5.0)
+        provider._last_writer_activity = time.monotonic() - 100000.0
+        assert lifecycle.demote_writer_to_reader(provider, idle_seconds=1.0) is True
+        assert provider._truth_writer_role == "reader"
+        provider.on_turn_start(2, "hello again")
+        assert provider._truth_writer_role == "owner"
+        thread = getattr(provider, "_writer_thread", None)
+        assert thread is not None and thread.is_alive()
+        assert _child_acquire_status(tmp_path / "scope-recall") == "STATUS:busy"
+    finally:
+        _shutdown(provider)

--- a/tests/test_writer_lease_idle_release.py
+++ b/tests/test_writer_lease_idle_release.py
@@ -16,6 +16,7 @@ import json
 import subprocess
 import sys
 import textwrap
+import threading
 import time
 from pathlib import Path
 
@@ -216,5 +217,74 @@ def test_demoted_runtime_re_promotes_on_next_turn(tmp_path: Path) -> None:
         thread = getattr(provider, "_writer_thread", None)
         assert thread is not None and thread.is_alive()
         assert _child_acquire_status(tmp_path / "scope-recall") == "STATUS:busy"
+    finally:
+        _shutdown(provider)
+
+
+def test_demote_refuses_while_digest_running(tmp_path: Path) -> None:
+    _write_config(tmp_path, {"vector": {"enabled": False}})
+    provider = _provider()
+    _initialize(provider, tmp_path, "digest-guard")
+    fake_digest = None
+    try:
+        assert provider._truth_writer_role == "owner"
+        lifecycle = _lifecycle_module(provider)
+        provider._last_writer_activity = time.monotonic() - 100000.0
+        stop = threading.Event()
+
+        def _fake_digest() -> None:
+            stop.wait(timeout=30.0)
+
+        fake_digest = threading.Thread(target=_fake_digest, daemon=True)
+        fake_digest.start()
+        provider._background_work().thread = fake_digest
+        assert (
+            lifecycle.demote_writer_to_reader(provider, idle_seconds=1.0) is False
+        )
+        assert provider._truth_writer_role == "owner"
+        assert _child_acquire_status(tmp_path / "scope-recall") == "STATUS:busy"
+    finally:
+        if fake_digest is not None:
+            stop.set()
+            fake_digest.join(timeout=5.0)
+        if provider._background_work() is not None:
+            provider._background_work().thread = None
+        _shutdown(provider)
+
+
+def test_default_config_leaves_release_disabled(tmp_path: Path) -> None:
+    # No writer_lease section at all: the feature must stay opt-in.
+    _write_config(tmp_path, {"vector": {"enabled": False}})
+    provider = _provider()
+    _initialize(provider, tmp_path, "default-disabled")
+    try:
+        assert provider._truth_writer_role == "owner"
+        lifecycle = _lifecycle_module(provider)
+        provider._last_writer_activity = time.monotonic() - 100000.0
+        lifecycle.maybe_idle_release_writer_lease(provider)
+        assert not getattr(provider, "_idle_release_in_progress", False)
+        time.sleep(0.2)
+        assert provider._truth_writer_role == "owner"
+    finally:
+        _shutdown(provider)
+
+
+def test_idle_release_config_is_clamped(tmp_path: Path) -> None:
+    _write_config(tmp_path, {"vector": {"enabled": False}})
+    provider = _provider()
+    _initialize(provider, tmp_path, "clamp-check")
+    try:
+        lifecycle = _lifecycle_module(provider)
+        provider._config["writer_lease"] = {"idle_release_seconds": "junk"}
+        assert lifecycle.idle_writer_lease_release_seconds(provider) == 0.0
+        provider._config["writer_lease"] = {"idle_release_seconds": -5}
+        assert lifecycle.idle_writer_lease_release_seconds(provider) == 0.0
+        provider._config["writer_lease"] = {"idle_release_seconds": 999999}
+        assert (
+            lifecycle.idle_writer_lease_release_seconds(provider)
+            == lifecycle.MAX_IDLE_WRITER_LEASE_SECONDS
+        )
+        provider._config["writer_lease"] = {"idle_release_seconds": 1800}
+        assert lifecycle.idle_writer_lease_release_seconds(provider) == 1800.0
     finally:
         _shutdown(provider)


### PR DESCRIPTION
## Summary

Implements #58: the cross-process truth writer lease is process-lifetime, so the first process to take it (typically a login-autostarted, often-idle messaging gateway) starves every later surface — including Hermes Desktop, the user's main workspace — for its whole lifetime.

This adds the symmetric counterpart to the existing reader→writer promotion probe (`_maybe_promote_to_writer`): **writer→reader voluntary demotion after a configurable idle window**. The feature is **opt-in**: default configuration ships unchanged behavior.

## Mechanism

- The capture writer loop's idle path checks (every 5s, two integer reads) whether the process has seen no user turn for `writer_lease.idle_release_seconds` (**default 0 = disabled**; set e.g. 1800 to opt in).
- When the window elapses, a daemon thread runs `demote_writer_to_reader`, mirroring the promotion path:
  1. Re-checks idleness and activity — a turn that started while the demote was spawning wins; **foreground turns, queued or in-flight capture writes, and a running background journal digest all veto the release with no side effects**.
  2. Quiesces the capture writer loop via a new `quiesce_writer_for_lease_release` — unlike `shutdown_writer` it never sets `_shutdown_requested`, so the runtime stays promotable.
  3. Closes the write pager, releases the OS lease, and re-initializes as the read-only runtime (the same fail-closed `mode='ro'` peer path used at startup).
- From then on, the existing on-turn promotion probe lets whichever process actually has user activity take the lease — including this process itself on its next turn.

The issue-#39 protection is unchanged: the OS lease still guarantees exactly one writer at any moment; only the hold-until-exit starvation is removed.

## Failure handling

- Idle-check / quiesce / close failures keep the writer role intact and retry on a later idle tick.
- If the write-pager close fails, the writer runtime is restored via the normal `initialize_writer_runtime` path.
- If the OS lease release itself fails (exotic), the runtime still becomes a reader so it stops writing; the leaked lease is reclaimed by the kernel at process exit.

## Compatibility

- **Stock behavior is unchanged**: the release only activates when `writer_lease.idle_release_seconds` is set to a positive value.
- No schema migration, no tool-name or provider-identity changes, no new env vars.
- Same-process peer providers keep the existing refcounted lease semantics: demoting one peer only drops its holder reference; the OS lease stays while another in-process owner lives.
- Rollback = revert this change, or leave the key at its default `0`.

## Tests

`tests/test_writer_lease_idle_release.py` (8 cases):

- idle writer releases and demotes, verified at the OS level by a **separate process** acquiring the lease afterwards
- recent activity suppresses the release
- explicit `idle_release_seconds: 0` disables the probe
- **missing config section leaves the feature disabled (opt-in contract)**
- foreground-busy veto
- **background-digest veto (never closes the digest's connection mid-transaction)**
- config clamping (junk / negative / oversized values)
- demoted runtime re-promotes on its next turn (full round trip, writer thread alive again)

## Test run

```
pytest tests/test_initialize_peer_recovery.py tests/test_capture_queue.py \
  tests/test_capture_shutdown.py tests/test_config_schema.py \
  tests/test_readonly_follower_tools.py tests/test_readonly_dry_run_contracts.py \
  tests/test_writer_lease_idle_release.py -q
→ 71 passed, 1 skipped (Windows 11, Python 3.11)
```

## Notes

- Config surface follows the existing four-way contract: `DEFAULT_CONFIG` + packaged `config.json` + `config_schema.py` description + `docs/configuration.md` entry, kept in sync (enforced by `test_config_schema.py`).
- Defaulting to opt-in keeps the merge gate minimal; if you later want this on by default, flipping `DEFAULT_IDLE_WRITER_LEASE_SECONDS` (and the packaged config) is a one-line change.
- Suggested operator value: 1800s — normal interactive use never releases mid-session, while an overnight-idle gateway reliably frees the lease by morning.
