### PR TITLE
Fix PyPI release gate workspace ordering

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -121,6 +121,20 @@ jobs:
           expected="v$(python -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')"
           test "${RELEASE_TAG}" = "${expected}"
           test "$(git tag --points-at HEAD | grep -Fx "${expected}")" = "${expected}"
+      - name: Verify checked-out tag matches release source
+        env:
+          VERIFIED_SOURCE_SHA: ${{ needs.verify_release_origin.outputs.source_sha }}
+        run: test "$(git rev-parse HEAD)" = "${VERIFIED_SOURCE_SHA}"
+      - name: Install release dependencies
+        run: |
+          python -m pip install --require-hashes -r constraints/release-hashed.txt
+          python -m pip install --no-deps ".[lancedb,dev]"
+          python .github/scripts/checkout_pinned_hermes.py
+          python -m pip install --no-deps -e .hermes-agent-src
+      - name: Run tagged release gate
+        env:
+          PYTHONPATH: .hermes-agent-src
+        run: python scripts/check.release.py --tagged-release
       - name: Download GitHub Release artifacts
         env:
           GH_TOKEN: ${{ github.token }}
@@ -227,16 +241,6 @@ jobs:
             echo "Unexpected PyPI status ${status} while checking ${version}" >&2
             exit 1
           fi
-      - name: Install release dependencies
-        run: |
-          python -m pip install --require-hashes -r constraints/release-hashed.txt
-          python -m pip install --no-deps ".[lancedb,dev]"
-          python .github/scripts/checkout_pinned_hermes.py
-          python -m pip install --no-deps -e .hermes-agent-src
-      - name: Run tagged release gate
-        env:
-          PYTHONPATH: .hermes-agent-src
-        run: python scripts/check.release.py --tagged-release
       - name: Validate staged distributions with Twine
         run: python -m twine check release-staging/packages/*
       - name: Upload reviewed release artifact

--- a/scripts/check.release.py
+++ b/scripts/check.release.py
@@ -2441,6 +2441,36 @@ def pypi_workflow_gate_check() -> dict[str, object]:
         failures.append("PyPI workflow does not publish to PyPI")
     if publish_marker in pypi_text and gate_marker in pypi_text and pypi_text.index(gate_marker) > pypi_text.index(publish_marker):
         failures.append("PyPI workflow invokes release gate after the publish step")
+    source_binding_marker = (
+        'test "$(git rev-parse HEAD)" = "${VERIFIED_SOURCE_SHA}"'
+    )
+    if source_binding_marker not in pypi_text:
+        failures.append(
+            "PyPI workflow does not bind the checked-out tag to the verified release source"
+        )
+    elif gate_marker in pypi_text and pypi_text.index(
+        source_binding_marker
+    ) > pypi_text.index(gate_marker):
+        failures.append(
+            "PyPI workflow must bind the checked-out tag to the verified release "
+            "source before executing the tagged release gate"
+        )
+    if gate_marker in pypi_text:
+        gate_position = pypi_text.index(gate_marker)
+        dirty_workspace_markers = (
+            "Download GitHub Release artifacts",
+            "Stage validated distributions",
+            "release-download",
+            "release-staging",
+        )
+        if any(
+            marker in pypi_text and pypi_text.index(marker) < gate_position
+            for marker in dirty_workspace_markers
+        ):
+            failures.append(
+                "PyPI workflow must run the tagged release gate before creating "
+                "release artifact work directories"
+            )
     if re.search(r"(?m)^  release:\s*$", pypi_text):
         failures.append(
             "PyPI workflow must not also trigger on GitHub Release published events"

--- a/tests/test_publish_workflows.py
+++ b/tests/test_publish_workflows.py
@@ -76,6 +76,49 @@ def test_pypi_reuses_github_release_artifacts_and_verifies_sha256():
     assert "skip-existing" not in pypi_text
 
 
+def test_pypi_runs_clean_tree_gate_before_artifact_work_directories():
+    pypi = yaml.safe_load(PYPI_WORKFLOW.read_text(encoding="utf-8"))
+    prepare_steps = pypi["jobs"]["prepare"]["steps"]
+    steps = [step.get("name") for step in prepare_steps]
+
+    assert steps.index("Verify tag matches package version") < steps.index(
+        "Verify checked-out tag matches release source"
+    )
+    assert steps.index("Verify checked-out tag matches release source") < steps.index(
+        "Install release dependencies"
+    )
+    assert steps.index("Install release dependencies") < steps.index(
+        "Run tagged release gate"
+    )
+    assert steps.index("Run tagged release gate") < steps.index(
+        "Download GitHub Release artifacts"
+    )
+    assert steps.index("Download GitHub Release artifacts") < steps.index(
+        "Verify GitHub Release artifact SHA-256"
+    )
+    assert steps.index("Verify GitHub Release artifact SHA-256") < steps.index(
+        "Verify source/run-bound release provenance"
+    )
+    assert steps.index("Verify source/run-bound release provenance") < steps.index(
+        "Stage validated distributions"
+    )
+    gate_position = steps.index("Run tagged release gate")
+    before_gate = "\n".join(str(step) for step in prepare_steps[:gate_position])
+    assert "release-download" not in before_gate
+    assert "release-staging" not in before_gate
+    source_step = next(
+        step
+        for step in prepare_steps
+        if step.get("name") == "Verify checked-out tag matches release source"
+    )
+    assert source_step["env"] == {
+        "VERIFIED_SOURCE_SHA": "${{ needs.verify_release_origin.outputs.source_sha }}"
+    }
+    assert source_step["run"] == (
+        'test "$(git rev-parse HEAD)" = "${VERIFIED_SOURCE_SHA}"'
+    )
+
+
 def test_pypi_workflow_is_per_tag_concurrent_and_refuses_repeat_upload():
     pypi = yaml.safe_load(PYPI_WORKFLOW.read_text(encoding="utf-8"))
     pypi_text = PYPI_WORKFLOW.read_text(encoding="utf-8")
@@ -262,6 +305,58 @@ def test_release_gate_rejects_pypi_packages_dir_that_includes_metadata(
 
     assert gate["ok"] is False
     assert any("distribution-only" in failure for failure in gate["failures"])
+
+
+def test_release_gate_rejects_artifact_work_directory_before_clean_tree_gate(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    workflows = tmp_path / ".github" / "workflows"
+    workflows.mkdir(parents=True)
+    shutil.copy2(RELEASE_WORKFLOW, workflows / "release.yml")
+    bad = PYPI_WORKFLOW.read_text(encoding="utf-8").replace(
+        "      - name: Install release dependencies\n",
+        "      - name: Create release workspace too early\n"
+        "        run: mkdir -p release-download\n"
+        "      - name: Install release dependencies\n",
+        1,
+    )
+    (workflows / "pypi.yml").write_text(bad, encoding="utf-8")
+    release_check = _load_release_check_module()
+    monkeypatch.setattr(release_check, "ROOT", tmp_path)
+
+    gate = release_check.pypi_workflow_gate_check()
+
+    assert gate["ok"] is False
+    assert any(
+        "before creating release artifact work directories" in failure
+        for failure in gate["failures"]
+    )
+
+
+def test_release_gate_rejects_missing_pre_execution_source_binding(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    workflows = tmp_path / ".github" / "workflows"
+    workflows.mkdir(parents=True)
+    shutil.copy2(RELEASE_WORKFLOW, workflows / "release.yml")
+    bad = PYPI_WORKFLOW.read_text(encoding="utf-8").replace(
+        'test "$(git rev-parse HEAD)" = "${VERIFIED_SOURCE_SHA}"',
+        'test -n "${VERIFIED_SOURCE_SHA}"',
+        1,
+    )
+    (workflows / "pypi.yml").write_text(bad, encoding="utf-8")
+    release_check = _load_release_check_module()
+    monkeypatch.setattr(release_check, "ROOT", tmp_path)
+
+    gate = release_check.pypi_workflow_gate_check()
+
+    assert gate["ok"] is False
+    assert any(
+        "bind the checked-out tag to the verified release source" in failure
+        for failure in gate["failures"]
+    )
 
 
 def test_release_gate_rejects_missing_tag_and_main_policy(


### PR DESCRIPTION
## Summary

- run the tagged clean-tree release gate before creating PyPI artifact work directories
- bind the checked-out tag to the verified GitHub Release source SHA before installing or executing source
- add static and regression coverage for both ordering invariants

## Why

The v2.0.0 PyPI prepare job created `release-download/` and `release-staging/` before invoking the tagged release gate. The gate correctly rejected those workflow-created untracked directories, so no package was uploaded.

## Validation

- `tests/test_publish_workflows.py`: 16 passed
- focused workflow security nodes: 5 passed
- Ruff on changed Python files: passed

After merge and required CI, the existing immutable v2.0.0 GitHub Release can be published through the manual PyPI workflow fallback without moving the tag or rebuilding the release artifacts.