### PR TITLE
Stabilize direct writer handoff regressions

### DIFF
--- a/tests/test_writer_idle_handoff.py
+++ b/tests/test_writer_idle_handoff.py
@@ -16,6 +16,7 @@ import pytest
 
 from plugins.memory import load_memory_provider
 
+import scope_recall._internal.runtime.writer_handoff as writer_handoff_module
 from scope_recall.config import DEFAULT_CONFIG, validate_config_override
 from scope_recall.capture import enqueue_store
 from writer_lease import (
@@ -49,6 +50,23 @@ _HANDOFF_STAGES = [
     "peer_write_committed",
     "former_owner_remains_reader",
 ]
+
+
+@pytest.fixture(autouse=True)
+def _disable_ambient_writer_handoff_scheduler(monkeypatch):
+    """Keep direct handoff regressions isolated from the live writer loop.
+
+    Tests that exercise scheduling retain the imported production function,
+    while the writer loop's dynamic import sees this no-op for the duration of
+    each test.  This prevents a background handoff from racing a direct
+    ``_perform_idle_handoff`` call after ``_make_idle`` moves the clock.
+    """
+
+    monkeypatch.setattr(
+        writer_handoff_module,
+        "maybe_schedule_idle_writer_handoff",
+        lambda _provider: False,
+    )
 
 
 def _provider():


### PR DESCRIPTION
## Why
Main CI #173 exposed a test-only race: direct idle-handoff regressions could run concurrently with the live writer loop's ambient scheduler after `_make_idle` moved the activity clock. The exact product tree had already passed the PR matrix; production scheduling remains serialized by its orchestration lock.

## Change
- disable only the ambient writer-loop scheduler during this regression module
- retain the imported production scheduler for the explicit scheduling test
- do not change Scope Recall runtime or package bytes

## Verification
- `tests/test_writer_idle_handoff.py`: 46 passed
- focused failed nodes plus scheduler node: 3 passed
- Ruff on the changed file: pass

Head SHA: cbca5634e74b3a5025a697c982b310598bbfb2ba  
Head tree: 36b01a07006e9c1362805ca2f4425cb957407319