### PR TITLE
Fix runtime reliability, online candidate review, and Windows native isolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to `scope-recall` will be documented in this file.
 - Requeue orphaned relation-frequency failures from current SQLite truth with bounded retries and supersession evidence. Writer-handoff preflight vetoes no longer resume a writer that was never quiesced (#66).
 - Supply an identifiable Scope Recall User-Agent for shared HTTP transports, including OpenAI-compatible and Anthropic nightly requests, while preserving provider-specific headers (#67).
 - Add live `scope_recall_memory` candidate `promote` and `archive` actions through the gateway's admitted writer. Plans default to dry-run, apply supports revision checks, scope and Fact authority remain enforced, and lifecycle/audit/vector intent commit atomically. Store receipts now report the persisted candidate lifecycle (#68).
+- Preserve a successful store result if its post-commit lifecycle receipt cannot be read. Return the committed id with lifecycle `unknown`, emit a content-free diagnostic, and never retry that successful write.
 - Keep Windows LanceDB/PyArrow operations in a private persistent helper process and load local sentence-transformers only when selected. Native helper failure or timeout becomes a recoverable companion error while SQLite truth and pending outbox work stay in the Hermes process (#69).
 
 ## [2.0.1] - 2026-08-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to `scope-recall` will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- Preserve valid L4 verdicts when a model exceeds the 120-character reason budget; sanitize and bound the explanation after strict verdict/schema validation (#65).
+- Reject duplicate JSON response fields instead of accepting the last of contradictory L4 verdicts, found during the accompanying protocol audit.
+- Requeue orphaned relation-frequency failures from current SQLite truth with bounded retries and supersession evidence. Writer-handoff preflight vetoes no longer resume a writer that was never quiesced (#66).
+- Supply an identifiable Scope Recall User-Agent for shared HTTP transports, including OpenAI-compatible and Anthropic nightly requests, while preserving provider-specific headers (#67).
+- Add live `scope_recall_memory` candidate `promote` and `archive` actions through the gateway's admitted writer. Plans default to dry-run, apply supports revision checks, scope and Fact authority remain enforced, and lifecycle/audit/vector intent commit atomically. Store receipts now report the persisted candidate lifecycle (#68).
+- Keep Windows LanceDB/PyArrow operations in a private persistent helper process and load local sentence-transformers only when selected. Native helper failure or timeout becomes a recoverable companion error while SQLite truth and pending outbox work stay in the Hermes process (#69).
+
 ## [2.0.1] - 2026-08-30
 
 This patch is cumulative since the last public release, `2.0.0`. It completes the production managed upgrade path for ordinary users and hardens the 2.0 memory runtime: one fixed official stable source, an external resumable idempotent operation journal, strict state transitions, exact-Hermes-home restart control, zero-signal recall admission, candidate isolation, and explicit observability ownership.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,18 @@
+# Contributors
+
+Scope Recall thanks contributors who improve its implementation, report defects,
+reproduce failures, and test fixes.
+
+The reliability fixes following 2.0.1 credit these issue reporters as commit
+co-authors for their reproduction and diagnosis work:
+
+| Contributor | Contribution |
+| --- | --- |
+| [JohnYinl](https://github.com/JohnYinl) | Reproduced the hidden L4 reason-length failure and tested prompt/parser remedies in [#65](https://github.com/410979729/scope-recall-hermes/issues/65). |
+| [849506054](https://github.com/849506054) | Traced orphan relation-frequency failures, retry storms, and writer fencing in [#66](https://github.com/410979729/scope-recall-hermes/issues/66). |
+| [ycheng87](https://github.com/ycheng87) | Reproduced missing User-Agent failures on protected nightly endpoints and supplied a local fix in [#67](https://github.com/410979729/scope-recall-hermes/issues/67). |
+| [yzy806806](https://github.com/yzy806806) | Identified the online candidate-review gap and misleading store lifecycle receipts in [#68](https://github.com/410979729/scope-recall-hermes/issues/68). |
+| [gfpyc](https://github.com/gfpyc) | Supplied Windows desktop Arrow crash evidence, affected configuration, and a working SQLite-backend workaround in [#69](https://github.com/410979729/scope-recall-hermes/issues/69). |
+
+See the [commit history](https://github.com/410979729/scope-recall-hermes/commits/main/)
+for implementation authors and additional contributions.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -24,11 +24,19 @@ That split is deliberate. SQLite is the durable source of truth; the configured 
 
 ### Bounded companion maintenance
 
+An orphan relation-frequency failure is durable repair evidence. Maintenance recreates missing dirty work from the current truth revision in a bounded transaction and records the superseded failure. Normal drain retries remain capped; an unrebuildable row stays visible as dead-letter debt. Writer-handoff preflight is side-effect free until quiescing begins, so an activity veto cannot fence a healthy running writer through a spurious resume failure.
+
 Relation statistics are a transactionally maintained SQLite companion rather than a foreground scope scan. Each truth mutation updates one indexed-memory row, the changed entity postings, and per-scope/entity document counts in the caller's transaction. Existing databases enter a paged, durable backfill state; foreground relation sync defers instead of silently scanning the scope while that state is incomplete. A blocked-entity threshold change creates resumable scope reclassification debt.
 
 Relation rebuild work is organized as monotonic passes. A peer or focus revision arriving during a leased pass records a next-pass revision without changing the active cursor, lease, lifetime processed count, attempts, or lifetime failures. New and changed peers carry their own rebuild events, and the active pass atomically promotes the latest pending revision only after reaching its current end.
 
 Vector startup uses the durable outbox before reconciliation. Once replayable debt is empty, one short SQLite transaction reads at most one `(updated_at, id)` truth page, writes deterministic outbox events, and advances the generation-bound watermark. Embedding and physical-store I/O happen only after that commit. Interrupted cycles resume from the persisted cursor and upper bound; ordinary startup never calls full vector enumeration or a stale-row sweep. Full duplicate/stale-vector audits remain explicit doctor/repair operations.
+
+### Process and command boundaries
+
+On Windows, the vector factory opens LanceDB through a persistent private subprocess over anonymous pipes. Only vector protocol operations cross this boundary; truth transactions, generation selection, write authority and outbox replay stay in Hermes. EOF, malformed protocol and timeout terminate the helper and surface a companion error. Operations are not implicitly retried; explicit reopen and the causal outbox govern recovery. Local sentence-transformers imports are lazy, preventing hosted/hash embedding configurations and the helper from loading PyTorch incidentally. Linux and macOS retain the existing native path.
+
+Online candidate review is a typed memory command on the existing tool/application/kernel/adapter path. Dry-runs use query access. Apply acquires the admitted writer and a clean `BEGIN IMMEDIATE` boundary before scope, lifecycle and Fact-ownership checks; the shared lifecycle service joins that transaction for truth, companions, audit and vector intent. A failed result rolls back the whole command. Revision tokens let an operator reject a plan that changed after review.
 
 ## Goals
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -38,6 +38,8 @@ On Windows, the vector factory opens LanceDB through a persistent private subpro
 
 Online candidate review is a typed memory command on the existing tool/application/kernel/adapter path. Dry-runs use query access. Apply acquires the admitted writer and a clean `BEGIN IMMEDIATE` boundary before scope, lifecycle and Fact-ownership checks; the shared lifecycle service joins that transaction for truth, companions, audit and vector intent. A failed result rolls back the whole command. Revision tokens let an operator reject a plan that changed after review.
 
+Store receipt enrichment follows the durable commit and has no write authority. An unavailable lifecycle read preserves the committed outcome and id, marks lifecycle unknown, and logs only the error type. It cannot reclassify a successful mutation as a failed write or trigger replay.
+
 ## Goals
 
 1. Fix cross-turn topic bleed caused by queued previous-turn recall.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,6 +6,7 @@ include CHANGELOG.md
 include LICENSE
 include SECURITY.md
 include CONTRIBUTING.md
+include CONTRIBUTORS.md
 include .env.example
 include py.typed
 recursive-include docs *.md

--- a/README.md
+++ b/README.md
@@ -824,6 +824,8 @@ Rows classified as low-value noise are only archived when the operator also pass
 
 While the gateway is running, use `scope_recall_memory` with `action="promote"` or `action="archive"` and a candidate `id`. The default dry-run returns a plan and revision token; send `dry_run=false` with the returned `expected_updated_at` and `expected_lifecycle` to apply it through the gateway writer. Only candidates in the current writable scope are eligible; Fact-owned rows require Fact actions. See [online candidate review](docs/governance-ui.md#online-review-through-the-running-gateway). `scope_recall_store` reports the row's actual lifecycle, including a candidate downgrade made by admission policy.
 
+If the post-commit lifecycle lookup is temporarily unavailable, a successful store still returns its committed id with lifecycle `unknown`. This does not trigger a second write; inspect the id later to confirm its lifecycle.
+
 ### Write-time governance
 
 Provider-owned captures apply a deterministic first line of governance before SQLite writes:

--- a/README.md
+++ b/README.md
@@ -452,7 +452,7 @@ When optional per-turn `capture_llm` extraction is enabled, Scope Recall redacts
 
 Vector backend choices:
 
-- `lancedb` — default ANN companion, best for normal hosts; install with `python -m pip install -e ".[lancedb]"`. Scope Recall probes LanceDB/PyArrow in a child process before importing them in the Hermes process, so SIGILL/illegal-instruction wheels are treated as unavailable instead of crashing the agent.
+- `lancedb` — default ANN companion, best for normal hosts; install with `python -m pip install -e ".[lancedb]"`. Scope Recall probes native wheels in a child process. On Windows, gateway/desktop vector operations also run in a private persistent helper so a later native crash cannot terminate Hermes. See [vector backends](docs/vector-backends.md).
 - `sqlite-bruteforce` — pure-Python/SQLite companion for non-AVX CPUs or hosts where importing LanceDB/PyArrow is unsafe; install with `python -m pip install -e .` and set `vector.backend` accordingly, or keep the default `vector.fallback_backend: sqlite-bruteforce` so a provably fresh bootstrap can select it when LanceDB is absent or unsafe. An active generation never switches backend during startup.
 - `pgvector` — optional PostgreSQL/pgvector companion for deployments that already operate PostgreSQL; install with `python -m pip install "hermes-scope-recall[pgvector]"` and configure `vector.pgvector.dsn_env` / `vector.pgvector.table_name`. See [`docs/vector-backends.md`](docs/vector-backends.md).
 
@@ -821,6 +821,8 @@ python scripts/promote.memory_candidates.py --hermes-home "$HERMES_HOME" --apply
 ```
 
 Rows classified as low-value noise are only archived when the operator also passes `--archive-noise`; otherwise they remain candidate/needs-review. Applied promotions and archives write `governance_audit_events` with before/after metadata and a batch id. `scripts/doctor.py` reports `runtime.memory_candidate_debt` so candidate backlog count, age, promotable rows, and archive candidates are visible before relying on promoted-only profile behavior.
+
+While the gateway is running, use `scope_recall_memory` with `action="promote"` or `action="archive"` and a candidate `id`. The default dry-run returns a plan and revision token; send `dry_run=false` with the returned `expected_updated_at` and `expected_lifecycle` to apply it through the gateway writer. Only candidates in the current writable scope are eligible; Fact-owned rows require Fact actions. See [online candidate review](docs/governance-ui.md#online-review-through-the-running-gateway). `scope_recall_store` reports the row's actual lifecycle, including a candidate downgrade made by admission policy.
 
 ### Write-time governance
 

--- a/_internal/application/memory_commands.py
+++ b/_internal/application/memory_commands.py
@@ -19,6 +19,15 @@ class StoreMemoryRequest:
 
 
 @dataclass(frozen=True, slots=True)
+class ReviewMemoryCandidateRequest:
+    memory_id: str
+    action: str
+    dry_run: bool = True
+    expected_updated_at: str = ""
+    expected_lifecycle: str = ""
+
+
+@dataclass(frozen=True, slots=True)
 class UpdateMemoryRequest:
     memory_id: str
     content: str
@@ -115,6 +124,8 @@ class PrivacyPurgeRequest:
 
 @runtime_checkable
 class MemoryCommandGateway(Protocol):
+    def review_candidate(self, request: ReviewMemoryCandidateRequest) -> dict[str, object]: ...
+
     def store(self, request: StoreMemoryRequest) -> tuple[str, bool, str]: ...
 
     def update(self, request: UpdateMemoryRequest) -> tuple[bool, str, str]: ...
@@ -146,6 +157,9 @@ class MemoryCommandApplication:
 
     def store(self, request: StoreMemoryRequest) -> tuple[str, bool, str]:
         return self._gateway.store(request)
+
+    def review_candidate(self, request: ReviewMemoryCandidateRequest) -> dict[str, object]:
+        return self._gateway.review_candidate(request)
 
     def update(self, request: UpdateMemoryRequest) -> tuple[bool, str, str]:
         return self._gateway.update(request)

--- a/_internal/runtime/command_adapter.py
+++ b/_internal/runtime/command_adapter.py
@@ -15,6 +15,7 @@ from ..application.memory_commands import (
     MemoryCommandGateway,
     MergeMemoriesRequest,
     PrivacyPurgeRequest,
+    ReviewMemoryCandidateRequest,
     StoreMemoryRequest,
     UpdateMemoryRequest,
 )
@@ -61,6 +62,19 @@ class ProviderCommandAdapter:
             except Exception:
                 _rollback_after_error(self._host, "store_now")
                 raise
+
+    def review_candidate(self, request: ReviewMemoryCandidateRequest) -> dict[str, object]:
+        from contextlib import nullcontext
+
+        access = nullcontext() if request.dry_run else write_kernel.command_write_access(
+            self._host, capture_barrier=True, user_initiated=True,
+        )
+        with access:
+            return memory_ops.review_memory_candidate(
+                self._host, memory_id=request.memory_id, action=request.action,
+                dry_run=request.dry_run, expected_updated_at=request.expected_updated_at,
+                expected_lifecycle=request.expected_lifecycle,
+            )
 
     def update(self, request: UpdateMemoryRequest) -> tuple[bool, str, str]:
         with write_kernel.command_write_access(self._host, user_initiated=True):

--- a/_internal/runtime/kernel.py
+++ b/_internal/runtime/kernel.py
@@ -14,6 +14,7 @@ from ..application.memory_commands import (
     GovernMemoriesRequest,
     MergeMemoriesRequest,
     PrivacyPurgeRequest,
+    ReviewMemoryCandidateRequest,
     StoreMemoryRequest,
     UpdateMemoryRequest,
 )
@@ -201,6 +202,11 @@ class _LegacyPersistCommandPort:
             ),
         )
 
+    def review_candidate(self, request: ReviewMemoryCandidateRequest) -> dict[str, object]:
+        from .command_adapter import ProviderCommandAdapter
+
+        return ProviderCommandAdapter(self._host).review_candidate(request)
+
     def update(self, request: UpdateMemoryRequest) -> tuple[bool, str, str]:
         fn = getattr(self._host, "_update_memory", None)
         if not callable(fn):
@@ -345,6 +351,14 @@ def bind_memory_command_port(obj: Any) -> MemoryCommandPort:
 
 class CommandKernel:
     """Build typed requests and invoke provider-neutral application commands."""
+
+    def review_candidate(
+        self, port: MemoryCommandPort, *, memory_id: str, action: str,
+        dry_run: bool = True, expected_updated_at: str = "", expected_lifecycle: str = "",
+    ) -> dict[str, object]:
+        return port.review_candidate(ReviewMemoryCandidateRequest(
+            memory_id, action, dry_run, expected_updated_at, expected_lifecycle,
+        ))
 
     def store(
         self,

--- a/_internal/runtime/ports.py
+++ b/_internal/runtime/ports.py
@@ -20,6 +20,7 @@ from ..application.memory_commands import (
     GovernMemoriesRequest,
     MergeMemoriesRequest,
     PrivacyPurgeRequest,
+    ReviewMemoryCandidateRequest,
     StoreMemoryRequest,
     UpdateMemoryRequest,
 )
@@ -93,6 +94,8 @@ class MemoryCommandPort(Protocol):
     """Provider-neutral application command surface."""
 
     def store(self, request: StoreMemoryRequest) -> tuple[str, bool, str]: ...
+
+    def review_candidate(self, request: ReviewMemoryCandidateRequest) -> dict[str, object]: ...
 
     def update(self, request: UpdateMemoryRequest) -> tuple[bool, str, str]: ...
 

--- a/_internal/runtime/tool_port.py
+++ b/_internal/runtime/tool_port.py
@@ -367,6 +367,29 @@ class ProviderToolRuntimeAdapter:
     def store_now(self, *args: Any, **kwargs: Any) -> Any:
         return self._command_kernel().store(self._resolve_command_port(), *args, **kwargs)
 
+    def review_candidate(self, **kwargs: Any) -> dict[str, Any]:
+        return self._command_kernel().review_candidate(self._resolve_command_port(), **kwargs)
+
+    def stored_memory_identity(self, memory_id: str) -> dict[str, Any]:
+        """Read a bounded, content-free receipt after a durable store."""
+        from ...candidate_review import candidate_identity_fields
+        from ...graph import load_metadata
+
+        if not memory_id:
+            return {}
+        if not any(callable(getattr(self._host, name, None)) for name in ("query_connection", "_require_conn")):
+            # Isolated legacy hosts may expose only a store hook. Do not claim
+            # promotion when that host cannot provide a persisted receipt.
+            return {}
+        with self.query_lock():
+            scopes = self.writable_scope_ids()
+            placeholders = ",".join("?" for _ in scopes) or "NULL"
+            row = self.query_connection().execute(
+                f"SELECT source, metadata FROM memories WHERE id=? AND scope_id IN ({placeholders})",
+                [memory_id, *scopes],
+            ).fetchone()
+        return candidate_identity_fields(source=str(row[0]), metadata=load_metadata(row[1])) if row else {}
+
     def update_memory(self, *args: Any, **kwargs: Any) -> Any:
         return self._command_kernel().update(self._resolve_command_port(), *args, **kwargs)
 

--- a/_internal/runtime/writer_handoff.py
+++ b/_internal/runtime/writer_handoff.py
@@ -892,6 +892,7 @@ def _perform_idle_handoff(provider: Any, state: Any) -> None:
     providers: tuple[Any, ...] = ()
     generations: dict[int, int] = {}
     teardown_started = False
+    quiesce_started = False
     release_started = False
     authority_released = False
     phase = "preflight"
@@ -936,6 +937,7 @@ def _perform_idle_handoff(provider: Any, state: Any) -> None:
         # released for the writer consumers to drain.
         _release_provider_locks(lifecycles)
         phase = "quiesce"
+        quiesce_started = True
         for peer in providers:
             quiesce_writer_for_handoff(peer, timeout=HANDOFF_LOCK_TIMEOUT_SECONDS)
         phase = "final_recheck"
@@ -1001,7 +1003,7 @@ def _perform_idle_handoff(provider: Any, state: Any) -> None:
         failure_code = _content_free_failure_code(exc, phase=phase)
         if not teardown_started:
             resume_failed = False
-            if not lifecycles and providers:
+            if quiesce_started and not lifecycles and providers:
                 try:
                     lifecycles = _acquire_provider_locks(
                         providers, "_writer_lifecycle_lock"
@@ -1009,7 +1011,7 @@ def _perform_idle_handoff(provider: Any, state: Any) -> None:
                 except Exception:
                     lifecycles = []
                     resume_failed = True
-            if providers and lifecycles:
+            if quiesce_started and providers and lifecycles:
                 try:
                     _abort_quiesced_handoff(providers)
                 except Exception:
@@ -1017,6 +1019,11 @@ def _perform_idle_handoff(provider: Any, state: Any) -> None:
                         "Scope Recall fenced writer handoff resume failed"
                     )
                     resume_failed = True
+            if not quiesce_started:
+                # A preflight veto has not stopped any writer. Resuming it can
+                # itself fail and incorrectly fence a healthy owner (#66).
+                for peer in providers:
+                    peer._writer_handoff_fenced = False
             if resume_failed:
                 failure_code = "writer_resume_failed"
                 for peer in providers:
@@ -1048,7 +1055,13 @@ def _perform_idle_handoff(provider: Any, state: Any) -> None:
             _set_process_failure(state, failure_code, uncertain=True)
         telemetry_event = "handoff_failed"
         telemetry_deactivate_owner = authority_released
-        logger.warning(
+        benign_veto = not teardown_started and failure_code in {
+            "recent_user_activity", "recent_truth_activity", "truth_work_active",
+            "foreground_busy", "capture_queue_pending", "capture_processing",
+            "digest_active", "activity_generation_changed",
+        }
+        log = logger.debug if benign_veto else logger.warning
+        log(
             "Scope Recall idle writer handoff did not complete (reason=%s)",
             failure_code,
         )

--- a/_lance_worker.py
+++ b/_lance_worker.py
@@ -1,0 +1,76 @@
+"""Private native vector worker. No Hermes runtime, model, or truth connection."""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import sys
+import types
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+
+def main() -> None:
+    # Directory plugins need a package alias; importing their __init__ would
+    # load the host integration and potentially torch into this native worker.
+    package = types.ModuleType("scope_recall")
+    package.__path__ = [str(Path(__file__).resolve().parent)]
+    sys.modules["scope_recall"] = package
+    if TYPE_CHECKING:
+        from . import vector_store
+        from .capture_filters import sanitize_report_text
+        from .lance_process_store import LANCE_WORKER_METHODS, MAX_LANCE_FRAME_BYTES
+        from .vector_store import LanceVectorStore
+    else:
+        from scope_recall import vector_store
+        from scope_recall.capture_filters import sanitize_report_text
+        from scope_recall.lance_process_store import LANCE_WORKER_METHODS, MAX_LANCE_FRAME_BYTES
+        from scope_recall.vector_store import LanceVectorStore
+
+    # This entire interpreter is already disposable. A second import-probe
+    # subprocess adds no isolation and complicates deadline/process ownership.
+    vector_store._NATIVE_VECTOR_PROBE = {"safe": True, "returncode": 0, "stdout": "", "stderr": ""}
+
+    store = None
+    # Keep protocol output on a private duplicate. Redirect the actual stdout
+    # descriptor as well as Python stdout: Arrow/Rust diagnostics may bypass
+    # contextlib and write directly to descriptor 1.
+    output = os.fdopen(os.dup(sys.stdout.fileno()), "wb", buffering=0)
+    os.dup2(sys.stderr.fileno(), sys.stdout.fileno())
+    try:
+        while True:
+            line = sys.stdin.buffer.readline(MAX_LANCE_FRAME_BYTES + 1)
+            if not line or len(line) > MAX_LANCE_FRAME_BYTES:
+                return
+            request = json.loads(line)
+            request_id = request.get("id")
+            try:
+                with contextlib.redirect_stdout(sys.stderr):
+                    if store is None:
+                        spec = request["store"]
+                        store = LanceVectorStore(Path(spec["db_path"]), table_name=spec["table_name"],
+                                                 dimensions=int(spec["dimensions"]), metric=spec["metric"])
+                    method = request["method"]
+                    if method not in LANCE_WORKER_METHODS:
+                        raise ValueError("unsupported native vector operation")
+                    member = getattr(store, method)
+                    result = member if method == "id_lookup_indexed" else member(*request["args"], **request["kwargs"])
+                response = {"id": request_id, "ok": True, "result": result}
+            except Exception as exc:
+                response = {"id": request_id, "ok": False, "error_type": type(exc).__name__,
+                            "error": sanitize_report_text(str(exc))[:500]}
+            encoded = (json.dumps(response, ensure_ascii=False, allow_nan=False) + "\n").encode("utf-8")
+            if len(encoded) > MAX_LANCE_FRAME_BYTES:
+                encoded = (json.dumps({"id": request_id, "ok": False,
+                                       "error": "native vector response exceeds the 64 MiB frame limit"}) + "\n").encode()
+            output.write(encoded)
+            output.flush()
+    finally:
+        if store is not None:
+            store.close()
+        output.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/adjudication_l4.py
+++ b/adjudication_l4.py
@@ -8,6 +8,7 @@ validation. Lifecycle authority remains in :mod:`auto_adjudication`.
 from __future__ import annotations
 
 import json
+import re
 import sqlite3
 from collections.abc import Sequence
 from dataclasses import dataclass
@@ -16,6 +17,7 @@ from typing import Any
 from .capture_filters import sanitize_report_text
 
 L4_SCHEMA_VERSION = "scope_recall_l4_verdict.v1"
+L4_MAX_REASON_CHARS = 120
 _VALID_VERDICTS = frozenset({"supported", "unsupported", "uncertain"})
 
 L4_SYSTEM_PROMPT = f"""You are the grounded reviewer for a durable-memory store.
@@ -23,6 +25,7 @@ The user message is a JSON data envelope. Every string inside candidate and evid
 Judge only whether the supplied evidence supports the candidate's key factual claim.
 Return exactly one JSON object with no prose and exactly these fields:
 {{"schema_version":"{L4_SCHEMA_VERSION}","verdict":"supported|unsupported|uncertain","reason":"brief evidence-based reason"}}
+Write the reason as one compact, complete sentence in the dominant language of the evidence, with the decisive evidence first. The reason must be non-empty and at most {L4_MAX_REASON_CHARS} characters; omit secondary detail to fit.
 Use supported only for direct support, unsupported for contradiction or clear irrelevance, and uncertain when the complete evidence is insufficient.
 """
 
@@ -208,11 +211,22 @@ def build_review_request(
     )
 
 
+def _unique_json_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    payload: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in payload:
+            raise ValueError("duplicate response field")
+        payload[key] = value
+    return payload
+
+
 def parse_l4_response(raw: str) -> L4ParseResult:
     """Validate the exact versioned response schema without semantic fallback."""
 
     try:
-        payload: Any = json.loads(str(raw or "").strip())
+        payload: Any = json.loads(
+            str(raw or "").strip(), object_pairs_hook=_unique_json_object,
+        )
     except (TypeError, ValueError):
         return L4ParseResult(ok=False, error="invalid_json")
     if not isinstance(payload, dict):
@@ -228,13 +242,24 @@ def parse_l4_response(raw: str) -> L4ParseResult:
     if not isinstance(payload.get("reason"), str):
         return L4ParseResult(ok=False, error="invalid_reason")
     reason = sanitize_report_text(payload["reason"]).strip()
-    if not reason or len(reason) > 120:
+    if not reason:
         return L4ParseResult(ok=False, error="invalid_reason")
+    if len(reason) > L4_MAX_REASON_CHARS:
+        # Verbosity is not a verdict/protocol failure. Prefer a complete sentence
+        # or word over a mid-token cut, and make omitted audit detail visible.
+        prefix = reason[: L4_MAX_REASON_CHARS - 3].rstrip()
+        sentences = list(re.finditer(r"[.!?。！？](?:\s|$)", prefix))
+        if sentences:
+            prefix = prefix[: sentences[-1].start() + 1]
+        elif " " in prefix:
+            prefix = prefix.rsplit(" ", 1)[0]
+        reason = prefix + "..."
     return L4ParseResult(ok=True, verdict=verdict, reason=reason)
 
 
 __all__ = [
     "L4_SCHEMA_VERSION",
+    "L4_MAX_REASON_CHARS",
     "L4Evidence",
     "L4ParseResult",
     "L4ReviewRequest",

--- a/candidate_review.py
+++ b/candidate_review.py
@@ -275,6 +275,7 @@ def review_candidate(
     actor: str = "scope-recall:candidate-review",
     expected_updated_at: str = "",
     expected_lifecycle: str = "",
+    commit: bool = True,
 ) -> dict[str, Any]:
     """Review one candidate using the shared lifecycle CAS transition."""
 
@@ -317,7 +318,10 @@ def review_candidate(
     if dry_run:
         return result
 
-    ensure_schema(conn)
+    if commit:
+        ensure_schema(conn)
+    elif not conn.in_transaction:
+        raise RuntimeError("candidate review requires an owned outer transaction")
     try:
         transition = transition_memory_lifecycle(
             conn,
@@ -335,9 +339,11 @@ def review_candidate(
             }[action],
             batch_id=str(after_metadata.get("candidate_promotion_batch_id") or ""),
         )
-        conn.commit()
+        if commit:
+            conn.commit()
     except LifecycleConflictError as exc:
-        conn.rollback()
+        if commit:
+            conn.rollback()
         return {
             "ok": False,
             "status": "conflict",
@@ -349,7 +355,8 @@ def review_candidate(
             "error": str(exc),
         }
     except Exception:
-        conn.rollback()
+        if commit:
+            conn.rollback()
         raise
     result["status"] = "applied"
     result["applied"] = True

--- a/docs/differences-from-memory-lancedb-pro.md
+++ b/docs/differences-from-memory-lancedb-pro.md
@@ -23,6 +23,8 @@ OpenClaw `memory-lancedb-pro` is fundamentally organized around its own LanceDB-
 
 This is deliberate so local auditing, backup, migration, and debugging remain simple.
 
+On Windows, LanceDB runs behind a private process boundary to contain native crashes independently of the Hermes model runtime. SQLite transactions and the durable vector outbox remain in the host. Candidate review runs as a scoped command through the active gateway writer, sharing the same atomic lifecycle/audit boundary as offline review.
+
 ### 2. Curated memory authority boundary
 
 In Hermes, built-in curated memory files are already authoritative:

--- a/docs/differences-from-memory-lancedb-pro.md
+++ b/docs/differences-from-memory-lancedb-pro.md
@@ -25,6 +25,8 @@ This is deliberate so local auditing, backup, migration, and debugging remain si
 
 On Windows, LanceDB runs behind a private process boundary to contain native crashes independently of the Hermes model runtime. SQLite transactions and the durable vector outbox remain in the host. Candidate review runs as a scoped command through the active gateway writer, sharing the same atomic lifecycle/audit boundary as offline review.
 
+Post-commit receipt lookup is separate from mutation success: an unavailable lifecycle read returns `unknown` with the committed id, without retrying the write.
+
 ### 2. Curated memory authority boundary
 
 In Hermes, built-in curated memory files are already authoritative:

--- a/docs/governance-ui.md
+++ b/docs/governance-ui.md
@@ -45,6 +45,27 @@ Apply behavior:
 - `supersede` marks the row superseded, records the replacement id, and removes graph companion entities/relations for that row.
 - every applied review writes a `memory_candidate_review` governance audit event.
 
+## Online review through the running gateway
+
+When the gateway owns the writer lease, use the existing `scope_recall_memory` tool to review one candidate without stopping Hermes. The CLI remains subject to the exclusive maintenance lease.
+
+First request a plan (omitting `dry_run` is equivalent to `true`):
+
+```json
+{"action": "promote", "id": "<candidate-id>"}
+```
+
+The result includes `before`, `after`, `expected_updated_at`, and `expected_lifecycle`. Apply the reviewed plan with its returned revision values:
+
+```json
+{"action": "promote", "id": "<candidate-id>", "dry_run": false,
+ "expected_updated_at": "<value-from-plan>", "expected_lifecycle": "candidate"}
+```
+
+Use `action="archive"` for the corresponding archive plan/apply flow. Each call handles one ID and requires an existing `candidate` in the current writable scope. Already processed event-digest rows are rejected; Fact-owned projections must use Fact actions. A stale revision returns a conflict. An applied review uses the live writer and commits the lifecycle, governance audit and vector outbox intent atomically. The outbox performs physical vector work after truth commits. Ordinary recall continues to exclude unreviewed candidates.
+
+Store receipts expose the actual persisted `lifecycle`, `origin_kind`, and review/admission identity. A temporary-marker admission downgrade therefore reports `candidate`, even when a store call succeeds.
+
 ## Safety boundaries
 
 - Candidate review does not delete SQLite truth rows.

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -10,6 +10,8 @@ These fixes require no schema migration or vector-generation rebuild. Existing W
 
 Background relation-frequency maintenance can recreate missing work for orphaned failure records from the current truth, keeping supersession evidence and the existing retry limit. No age-based failure deletion or full foreground scope rebuild is performed. Online candidate review is available through the running gateway; CLI maintenance still obeys the exclusive writer lease. See [candidate review](governance-ui.md#online-review-through-the-running-gateway).
 
+Store receipts may report lifecycle `unknown` if a post-commit lookup fails. The committed id and store outcome remain valid; use that id for later inspection rather than repeating the write.
+
 ### Schema migration status
 
 Before mutating older profile data, inspect the SQLite schema ledger without repairing it implicitly:

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -4,6 +4,12 @@ This document describes how to move into `scope-recall` from earlier local exper
 
 ## Supported migration paths
 
+### Runtime reliability fixes after 2.0.1
+
+These fixes require no schema migration or vector-generation rebuild. Existing Windows LanceDB generations retain their backend/model identity and are opened through an isolated helper process after restart. Local embedding models are loaded only when selected. A failed helper leaves SQLite truth and durable vector intent available for recovery; it never silently adopts another backend for an active generation.
+
+Background relation-frequency maintenance can recreate missing work for orphaned failure records from the current truth, keeping supersession evidence and the existing retry limit. No age-based failure deletion or full foreground scope rebuild is performed. Online candidate review is available through the running gateway; CLI maintenance still obeys the exclusive writer lease. See [candidate review](governance-ui.md#online-review-through-the-running-gateway).
+
 ### Schema migration status
 
 Before mutating older profile data, inspect the SQLite schema ledger without repairing it implicitly:

--- a/docs/reliability-audit.2026-09.md
+++ b/docs/reliability-audit.2026-09.md
@@ -15,6 +15,7 @@ maintenance, candidate lifecycle authority, and Windows vector failure isolation
 | HTTP requests (#67) | Main LLM paths inherited urllib's default client identity. | Add a truthful Scope Recall User-Agent at the shared safe transport boundary; retain explicit provider headers and redirect policy. |
 | Online review (#68) | CLI required a writer lease held by the running gateway; the gateway lacked candidate actions. | Add typed promote/archive commands to its existing memory dispatcher, default to dry-run, and reuse lifecycle/audit/outbox transactions. |
 | Store receipt (#68) | Successful writes were described as promoted even after policy routed them to candidate. | Project the persisted lifecycle and admission identity into the receipt. |
+| Post-commit receipt audit | A failed lifecycle lookup could turn an already committed store into a tool error and invite duplicate submissions. | Preserve the committed outcome and id, mark lifecycle unknown, and log only the error type without retrying the write. |
 | Windows native runtime (#69) | Runtime native operations shared a process with model libraries; a hard Arrow crash could terminate Hermes. | Use a private persistent vector helper, lazy local-model imports, bounded framed transport and explicit recovery. |
 | Helper recovery audit | A dead helper could consume repeated outbox attempts; native stdout could corrupt the protocol. | Mark it as requiring reopen before further claims, preserve retry work, and isolate protocol output from native stdout. |
 
@@ -40,6 +41,14 @@ maintenance, candidate lifecycle authority, and Windows vector failure isolation
   dependencies in their own CLI processes. The new isolation covers gateway and
   desktop vector runtime paths. These standalone tools could later share one
   isolated backend interface.
+- The Windows native Lance dependency can fail when generated data-file paths
+  exceed the platform's long-path boundary. Both the existing in-process store
+  and the helper reproduced this with 261/265-character data paths; unchanged
+  migration tests passed with a shorter storage root. Use short storage paths
+  on affected Windows installations.
+- Worker frames are limited to 64 MiB and requests to 60 seconds. Bulk APIs such
+  as `list_records` still return a complete result, so very large migrations
+  need a future paginated or chunked interface rather than an unbounded frame.
 - A failed helper requires explicit repair or provider restart. It stays marked
   `needs_repair` and cannot serve vector queries or consume further replay
   attempts until reopened. Lexical recall and durable SQLite state remain usable.

--- a/docs/reliability-audit.2026-09.md
+++ b/docs/reliability-audit.2026-09.md
@@ -1,0 +1,55 @@
+# September 2026 reliability audit
+
+This audit accompanies the fixes for issues #65–#69. Issue #41 is outside this
+change. The review concentrates on protocol parsing, writer ownership, relation
+maintenance, candidate lifecycle authority, and Windows vector failure isolation.
+
+## Findings fixed
+
+| Failure boundary | Root cause | Repair |
+| --- | --- | --- |
+| L4 response (#65) | A hidden reason-length limit discarded otherwise valid verdicts. | Share the prompt/parser budget, sanitize and bound valid reasons, retain strict schema validation. |
+| L4 response audit | JSON decoding accepted contradictory duplicate fields. | Reject duplicate keys as protocol errors, including either verdict order. |
+| Relation work (#66) | A failure without corresponding change work could never be consumed and blocked scope snapshots. | Reconstruct current-truth work under a higher generation, record supersession, rebuild within bounded retries, and refresh both old/current scopes. |
+| Writer ownership (#66) | A preflight veto could call resume despite no quiesce, allowing resume failure to fence a healthy writer. | Resume only after quiescing actually began; ordinary activity vetoes are debug events. |
+| HTTP requests (#67) | Main LLM paths inherited urllib's default client identity. | Add a truthful Scope Recall User-Agent at the shared safe transport boundary; retain explicit provider headers and redirect policy. |
+| Online review (#68) | CLI required a writer lease held by the running gateway; the gateway lacked candidate actions. | Add typed promote/archive commands to its existing memory dispatcher, default to dry-run, and reuse lifecycle/audit/outbox transactions. |
+| Store receipt (#68) | Successful writes were described as promoted even after policy routed them to candidate. | Project the persisted lifecycle and admission identity into the receipt. |
+| Windows native runtime (#69) | Runtime native operations shared a process with model libraries; a hard Arrow crash could terminate Hermes. | Use a private persistent vector helper, lazy local-model imports, bounded framed transport and explicit recovery. |
+| Helper recovery audit | A dead helper could consume repeated outbox attempts; native stdout could corrupt the protocol. | Mark it as requiring reopen before further claims, preserve retry work, and isolate protocol output from native stdout. |
+
+## Preserved contracts
+
+- SQLite owns truth. Physical vector writes follow durable outbox intent; native
+  failure never triggers truth deletion or an active-generation backend switch.
+- Online review resolves writable scope before returning snapshots, rejects
+  already processed candidates and Fact-owned projections, and supports revision
+  comparison. Audit failure rolls the entire mutation back.
+- Recovered relation failures are rebuilt from current truth. Deleted and moved
+  rows are covered, as are poisoned rows that reach a terminal retry budget.
+- Core tool count and cost ceilings stay unchanged. The reviewed schema snapshot
+  is 9,588 characters / 2,397 estimated tokens; see [D-013](tool-profiles.2.0.md).
+
+## Remaining architecture debt and validation limits
+
+- Compatibility adapters still accept structural `Any` hosts and use reflective
+  lookup of legacy provider methods. Existing architecture tests contain this
+  boundary. Replacing it requires a deliberate compatibility change; the review
+  did not demonstrate an authority bypass through it.
+- Explicit offline Doctor/migration/repair scripts can still load native
+  dependencies in their own CLI processes. The new isolation covers gateway and
+  desktop vector runtime paths. These standalone tools could later share one
+  isolated backend interface.
+- A failed helper requires explicit repair or provider restart. It stays marked
+  `needs_repair` and cannot serve vector queries or consume further replay
+  attempts until reopened. Lexical recall and durable SQLite state remain usable.
+- Tests inject hard exits and timeouts and exercise real LanceDB I/O, including
+  a physical commit followed by an exit before acknowledgement. The original
+  reporter's desktop dump and exact native wheel combination were not reproduced.
+- HTTP tests inspect actual requests on a local endpoint. Acceptance by a
+  particular Cloudflare deployment depends on its policy and was not probed with
+  the reporter's credentials.
+
+The issue reporters' reproduction and diagnosis contributions are recorded in
+[CONTRIBUTORS.md](../CONTRIBUTORS.md) and commit co-author trailers. This bounded
+review is not a claim that every possible repository defect has been excluded.

--- a/docs/tool-profiles.2.0.md
+++ b/docs/tool-profiles.2.0.md
@@ -7,25 +7,33 @@ independent local feature gates and handler checks.
 
 | Profile | Intended use | Measured tools | Schema chars | Estimated tokens |
 |---|---|---:|---:|---:|
-| `core` | Default Primary Agent store, recall, context, and compact dispatch | 6 | 9,531 | 2,383 |
+| `core` | Default Primary Agent store, recall, context, and compact dispatch | 6 | 9,588 | 2,397 |
 | `compatibility` | Historical individual V1 schemas | 20 | 15,830 | 3,958 |
-| `maintenance` | Core plus explicitly authorized maintenance | 17 | 17,346 | 4,337 |
-| `developer` | Core plus read-only inspection and diagnostics | 12 | 12,267 | 3,067 |
-| `extension` | Core plus separately enabled extension tools | 11 | 11,903 | 2,976 |
+| `maintenance` | Core plus explicitly authorized maintenance | 17 | 17,403 | 4,351 |
+| `developer` | Core plus read-only inspection and diagnostics | 13 | 13,058 | 3,265 |
+| `extension` | Core plus separately enabled extension tools | 11 | 11,960 | 2,990 |
 
 The measurements use compact, sorted JSON from the exact source schemas in this
 candidate and the conservative four-characters-per-token estimate. Maintenance
 was measured with `maintenance_tools_enabled=true`; extension was measured with
-Experience enabled. The core bytes are exactly the same surface as the previous
-`compact` baseline, so the default profile introduces no schema-budget growth.
+Experience enabled. The online candidate-review amendment adds 57 core schema
+characters over the 2.0.1 baseline after removing redundant parameter descriptions.
 
 The release gate freezes the current core snapshot under Decision D-013: 6
-tools, 9,531 schema characters, at most 9,600 characters, at most 2,400
+tools, 9,588 schema characters, at most 9,600 characters, at most 2,400
 conservatively estimated tokens, and canonical schema SHA-256
-`7380485b5ee769b60383e7f6eabb836dd1637553bbbf17883bb6e564def8f5d6`.
+`d19b08d445c17c265ee216acfe06060714ac1848917d5e7d70aa0dc05edd615d`.
 The count is a reviewed snapshot, not a permanent product-wide tool-count rule.
 Any schema or digest change requires an explicit policy/Decision Log update;
 moving a tool to another profile remains preferable to silent core growth.
+
+### D-013 amendment: online candidate review (2026-09-05)
+
+Issue #68 requires the live writer to review one candidate without stopping the
+gateway. Add `promote`/`archive`, dry-run, and revision parameters to the existing
+memory dispatcher. Preserve the six-tool core surface and both existing cost
+ceilings. Consolidate redundant descriptions while retaining plan/apply guidance;
+update the exact digest and regression snapshot alongside this decision.
 
 `compact` remains an accepted alias for `core`. `standard`, `legacy`, and
 `compat` remain accepted aliases for `compatibility`. No public tool name or

--- a/docs/vector-backends.md
+++ b/docs/vector-backends.md
@@ -10,7 +10,15 @@ Scope Recall keeps SQLite memory rows as the source of truth. Vector stores are 
 
 The alias `sqlite` is normalized to `sqlite-bruteforce`.
 
+## Windows native isolation
+
+Windows gateway/desktop LanceDB operations run in a persistent private helper process over anonymous pipes. The Hermes process retains the embedder, authoritative SQLite connection, generation manifest and causal outbox. Sentence-transformers/PyTorch is loaded lazily only when a local embedding model is selected. This contains the class of native Arrow crashes reported after local-model startup; it does not claim to diagnose or repair every incompatible native wheel.
+
+A native helper exit, invalid response or operation timeout closes the helper and returns a companion failure. The protocol bounds individual frames to 64 MiB and requests to 60 seconds. Mutations are not automatically resent because a timed-out operation may have completed; normal outbox replay and explicit store reopen govern recovery. SQLite truth is preserved and ordinary recall can degrade to lexical retrieval. The existing dependency constraints, generation identity checks and explicit repair workflow still apply. Linux and macOS retain their existing in-process backend.
+
 ## Public health contract
+
+After a helper failure, use the online `scope_recall_repair` tool (with `maintenance_tools_enabled=true`) or restart the provider to reopen it before retrying companion work. Background retries do not silently reopen a failed helper. Explicit offline Doctor, migration, and repair scripts may still load native libraries inside their own CLI process; they are separate from the live gateway process and remain subject to native-wheel compatibility.
 
 Runtime stats and the combined Doctor vector report expose one four-state contract: `ready`, `degraded`, `needs_repair`, or `disabled`. Detailed conditions are carried by `reason_code`, never by extra state values. The same payload includes `auto_recoverable`, `repair_required`, `usable_for_query`, `message`, and aggregate `debt_counts`.
 

--- a/embedders.py
+++ b/embedders.py
@@ -6,10 +6,14 @@ from __future__ import annotations
 
 import hashlib
 import importlib
+import json as _json_lib
 import math
 import os
 import threading
 import time
+import urllib.error
+import urllib.parse
+import urllib.request
 from concurrent.futures import Future
 from dataclasses import dataclass
 from functools import partial
@@ -48,16 +52,9 @@ try:
 except Exception:  # pragma: no cover - optional dependency of OpenAI adapters
     _httpx = None
 
-try:
-    from sentence_transformers import SentenceTransformer  # type: ignore[reportMissingImports]
-except Exception:  # pragma: no cover - optional dependency
-    SentenceTransformer = None
-
-import urllib.error
-import urllib.parse
-import urllib.request
-import json as _json_lib
-
+# Resolve only when the local embedder is selected. Importing this module for a
+# hosted/hash embedder must not load torch or other optional native runtimes.
+SentenceTransformer: Any = None
 
 _KNOWN_EMBEDDING_DIMS = {
     "hash-v1": 256,

--- a/http_utils.py
+++ b/http_utils.py
@@ -22,6 +22,9 @@ except ImportError:  # pragma: no cover - direct script import style
     from capture_filters import redact_secret_like_text
 
 logger = logging.getLogger(__name__)
+DEFAULT_USER_AGENT = (
+    "ScopeRecall/2.0 (+https://github.com/410979729/scope-recall-hermes)"
+)
 
 _PUBLIC_ENDPOINT_PATH_SUFFIXES = (
     "/v1/chat/completions",
@@ -419,6 +422,10 @@ def prepare_safe_request(
         dict(request.header_items()),
         allow_insecure=allow_insecure,
     )
+    # Set this at the shared transport boundary so nightly, capture, and
+    # embedding calls all identify the client. Preserve provider-specific UAs.
+    if not any(name.casefold() == "user-agent" for name in headers):
+        headers["User-Agent"] = DEFAULT_USER_AGENT
     return urllib.request.Request(
         policy.url,
         data=request.data,

--- a/lance_process_store.py
+++ b/lance_process_store.py
@@ -1,0 +1,242 @@
+"""Contain Windows Arrow/Lance native failures in a private local worker.
+
+SQLite truth and generation identities remain in the host. The worker owns only
+the selected Lance table and speaks a bounded, sequential JSON protocol over
+anonymous pipes. A crash/timeout is never retried here: writes with an uncertain
+physical outcome remain owned by the existing idempotent vector outbox.
+"""
+
+from __future__ import annotations
+
+import json
+import queue
+import subprocess
+import sys
+import threading
+import weakref
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+from .vector_store import VectorRecord, VectorStoreCompatibilityError, _python_subprocess_options, vector_record_to_dict
+
+MAX_LANCE_FRAME_BYTES = 64 * 1024 * 1024
+LANCE_WORKER_METHODS = frozenset({
+    "is_available", "open", "open_existing", "open_existing_for_update",
+    "close", "upsert_records", "delete", "delete_by_ids", "contains_id",
+    "list_ids", "list_records", "sample_metadata", "repair_records", "search",
+    "count_rows", "audit_counts", "id_lookup_indexed",
+})
+
+
+def _worker_command() -> list[str]:
+    return [sys.executable, str(Path(__file__).with_name("_lance_worker.py"))]
+
+
+def _write_worker_frame(stream: Any, encoded: bytes, output: queue.Queue) -> None:
+    try:
+        stream.write(encoded)
+        stream.flush()
+    except (OSError, ValueError):
+        try:
+            output.put(None, timeout=1)
+        except queue.Full:
+            pass
+
+
+def _stop_worker(process: subprocess.Popen) -> None:
+    if process.poll() is None:
+        try:
+            process.terminate()
+        except OSError:
+            # The worker can exit between poll() and TerminateProcess().
+            if process.poll() is None:
+                raise
+        try:
+            process.wait(timeout=3)
+        except subprocess.TimeoutExpired:
+            try:
+                process.kill()
+            except OSError:
+                if process.poll() is None:
+                    raise
+            process.wait(timeout=3)
+    for stream in (process.stdin, process.stdout):
+        if stream is not None:
+            stream.close()
+
+
+def _read_worker_frames(stream: Any, output: queue.Queue) -> None:
+    try:
+        while True:
+            line = stream.readline(MAX_LANCE_FRAME_BYTES + 1)
+            if not line or len(line) > MAX_LANCE_FRAME_BYTES:
+                break
+            output.put(json.loads(line), timeout=1)
+    except (ValueError, OSError, queue.Full):
+        pass
+    finally:
+        try:
+            output.put(None, timeout=1)
+        except queue.Full:
+            pass
+
+
+class ProcessLanceVectorStore:
+    """VectorStore implementation with no Lance/PyArrow imports in the host."""
+
+    def __init__(self, db_path: Path, *, table_name: str, dimensions: int, metric: str = "cosine") -> None:
+        self.db_path = Path(db_path)
+        self.table_name = table_name
+        self.dimensions = int(dimensions)
+        self.backend = "lancedb"
+        self._metric = metric
+        self._lock = threading.RLock()
+        self._process: subprocess.Popen | None = None
+        self._reader: threading.Thread | None = None
+        self._sender: threading.Thread | None = None
+        self._responses: queue.Queue = queue.Queue(maxsize=2)
+        self._finalizer: Any = None
+        self._failed = False
+        self._closed = False
+        self._sequence = 0
+        self._request_timeout = 60.0
+
+    def _start(self) -> None:
+        self._process = subprocess.Popen(
+            _worker_command(),
+            stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
+            **_python_subprocess_options(),
+        )
+        self._finalizer = weakref.finalize(self, _stop_worker, self._process)
+        self._reader = threading.Thread(
+            target=_read_worker_frames, args=(self._process.stdout, self._responses),
+            name="scope-recall-lance-pipe", daemon=True,
+        )
+        self._reader.start()
+
+    def _call(self, method: str, *args: Any, **kwargs: Any) -> Any:
+        if method not in LANCE_WORKER_METHODS:
+            raise ValueError("unsupported native vector operation")
+        with self._lock:
+            if self._failed or self._closed:
+                raise RuntimeError("native vector worker is closed; reopen the vector runtime explicitly")
+            self._sequence += 1
+            request = {
+                "id": self._sequence, "method": method, "args": args, "kwargs": kwargs,
+                "store": {"db_path": str(self.db_path), "table_name": self.table_name,
+                          "dimensions": self.dimensions, "metric": self._metric},
+            }
+            encoded = (json.dumps(request, ensure_ascii=False, allow_nan=False) + "\n").encode("utf-8")
+            if len(encoded) > MAX_LANCE_FRAME_BYTES:
+                raise ValueError("native vector request exceeds the 64 MiB frame limit")
+            try:
+                if self._process is None:
+                    self._start()
+                assert self._process is not None and self._process.stdin is not None
+                # A wedged native worker may stop reading stdin. Include pipe
+                # backpressure in the deadline rather than blocking on write.
+                self._sender = threading.Thread(
+                    target=_write_worker_frame,
+                    args=(self._process.stdin, encoded, self._responses), daemon=True,
+                    name="scope-recall-lance-send",
+                )
+                self._sender.start()
+                response = self._responses.get(timeout=self._request_timeout)
+                if not isinstance(response, dict) or response.get("id") != self._sequence:
+                    raise RuntimeError("native vector worker exited or returned an invalid frame")
+            except (OSError, ValueError, queue.Empty, RuntimeError) as exc:
+                self._failed = True
+                self.close()
+                raise RuntimeError(
+                    "native vector worker failed; SQLite truth is intact and unacknowledged outbox work remains pending"
+                ) from exc
+            if not response.get("ok"):
+                error_type = response.get("error_type")
+                message = str(response.get("error") or "native vector operation failed")
+                if error_type == "VectorStoreCompatibilityError":
+                    raise VectorStoreCompatibilityError(message)
+                if error_type == "FileNotFoundError":
+                    raise FileNotFoundError(message)
+                raise RuntimeError(message)
+            return response.get("result")
+
+    @property
+    def requires_reopen(self) -> bool:
+        """True after a transport failure, until an explicit open resets it."""
+        return self._failed
+
+    @property
+    def id_lookup_indexed(self) -> bool:
+        return bool(self._call("id_lookup_indexed"))
+
+    def is_available(self) -> bool:
+        return bool(self._call("is_available"))
+
+    def _reopen(self) -> None:
+        if self._closed:
+            self._process = None
+            self._reader = None
+            self._sender = None
+            self._responses = queue.Queue(maxsize=2)
+            self._failed = False
+            self._closed = False
+
+    def open(self) -> None:
+        with self._lock:
+            self._reopen()
+            self._call("open")
+
+    def open_existing(self) -> None:
+        with self._lock:
+            self._reopen()
+            self._call("open_existing")
+
+    def open_existing_for_update(self) -> None:
+        with self._lock:
+            self._reopen()
+            self._call("open_existing_for_update")
+
+    def upsert(self, record: VectorRecord | Mapping[str, Any]) -> None:
+        self.upsert_records([vector_record_to_dict(record)])
+
+    def upsert_records(self, rows: Iterable[dict[str, Any]]) -> None:
+        self._call("upsert_records", list(rows))
+
+    def delete(self, ids: list[str]) -> int:
+        return int(self._call("delete", ids))
+
+    def delete_by_ids(self, ids: list[str]) -> None:
+        self._call("delete_by_ids", ids)
+
+    def contains_id(self, memory_id: str) -> bool:
+        return bool(self._call("contains_id", memory_id))
+
+    def list_ids(self) -> list[str]:
+        return self._call("list_ids")
+
+    def list_records(self) -> dict[str, dict[str, Any]]:
+        return self._call("list_records")
+
+    def sample_metadata(self, *, limit: int = 200, offset: int = 0) -> list[dict[str, Any]]:
+        return self._call("sample_metadata", limit=limit, offset=offset)
+
+    def repair_records(self, desired_records: dict[str, dict[str, Any]]) -> int:
+        return int(self._call("repair_records", desired_records))
+
+    def search(self, vector: list[float], *, scope_id: str, limit: int) -> list[dict[str, Any]]:
+        return self._call("search", vector, scope_id=scope_id, limit=limit)
+
+    def count_rows(self) -> int:
+        return int(self._call("count_rows"))
+
+    def audit_counts(self) -> dict[str, int]:
+        return self._call("audit_counts")
+
+    def close(self) -> None:
+        with self._lock:
+            self._closed = True
+            if self._finalizer is not None and self._finalizer.alive:
+                self._finalizer()
+            for thread in (self._sender, self._reader):
+                if thread is not None and thread is not threading.current_thread():
+                    thread.join(timeout=3)

--- a/memory_ops.py
+++ b/memory_ops.py
@@ -578,6 +578,42 @@ def _target_scope_mode_for_existing(provider: Any, row: Any, target: str) -> str
     return default_mode
 
 
+def review_memory_candidate(
+    provider: Any, *, memory_id: str, action: str, dry_run: bool = True,
+    expected_updated_at: str = "", expected_lifecycle: str = "",
+) -> dict[str, Any]:
+    """Review a candidate using the live writer and the existing lifecycle CAS."""
+    from .candidate_review import review_candidate
+
+    def review(conn: Any) -> dict[str, Any]:
+        row = conn.execute(
+            f"SELECT metadata FROM memories WHERE id=? AND scope_id IN ({_domain_writable_placeholders(provider)})",
+            [memory_id, *_domain_writable_scope_ids(provider)],
+        ).fetchone()
+        if row is None:
+            return {"ok": False, "status": "not_found", "error": "candidate not found in writable scope", "applied": False}
+        if load_metadata(row[0]).get("lifecycle") != "candidate":
+            return {"ok": False, "status": "invalid_state", "error": "memory is not a candidate", "applied": False}
+        fact_error = _fact_mutation_error_payload(conn, [memory_id], operation="candidate review")
+        if fact_error is not None:
+            return {"ok": False, "status": "invalid_state", "applied": False, **fact_error}
+        return review_candidate(
+            conn, memory_id=memory_id, action=action, dry_run=dry_run,
+            actor="scope_recall_memory", expected_updated_at=expected_updated_at,
+            expected_lifecycle=expected_lifecycle, commit=False,
+        )
+
+    if dry_run:
+        with _command_lock(provider):
+            return review(_command_conn(provider))
+    mutation = MemoryMutationService(provider)
+    with mutation.transaction() as conn:
+        result = review(conn)
+        if not result.get("ok"):
+            mutation.abort(conn)
+    return result
+
+
 def update_memory(
     provider: Any, memory_id: str, content: str, target: str | None = None
 ) -> tuple[bool, str, str]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,7 @@ package-dir = {"scope_recall" = "."}
   "DESIGN.md",
   "CHANGELOG.md",
   "CONTRIBUTING.md",
+  "CONTRIBUTORS.md",
   "LICENSE",
   "SECURITY.md",
   "MANIFEST.in",

--- a/relation_frequency_maintenance.py
+++ b/relation_frequency_maintenance.py
@@ -162,6 +162,65 @@ def _record_frequency_failure(
     return status
 
 
+def _requeue_orphaned_frequency_failures(
+    conn: sqlite3.Connection,
+    limit: int,
+    *,
+    deadline_monotonic: float,
+    clock: Callable[[], float],
+) -> int:
+    """Reconstruct lost dirty work before superseding its durable failure.
+
+    A failure without a change row can never reach the normal retry consumer.
+    Rebuild from current truth under a new generation instead of deleting the
+    failure on age alone. A failed rebuild retains its change row and therefore
+    exhausts the ordinary retry budget rather than being resurrected forever.
+    """
+
+    rows = conn.execute(
+        """
+        SELECT f.memory_id, f.work_generation, f.old_scope_id, f.new_scope_id
+        FROM relation_frequency_failures f
+        WHERE NOT EXISTS (
+            SELECT 1 FROM relation_frequency_changes c WHERE c.memory_id=f.memory_id
+        )
+        ORDER BY f.last_failed_at, f.memory_id LIMIT ?
+        """,
+        (max(0, int(limit)),),
+    ).fetchall()
+    recovered = 0
+    for row in rows:
+        if clock() >= deadline_monotonic:
+            break
+        memory_id = str(row[0])
+        requested_at = _now_iso()
+        # BEGIN held by the caller serializes this with competing truth writers.
+        conn.execute(
+            """
+            INSERT INTO relation_frequency_generations(memory_id, last_generation, updated_at)
+            VALUES(?, ?, ?)
+            ON CONFLICT(memory_id) DO UPDATE SET
+                last_generation=MAX(relation_frequency_generations.last_generation+1,
+                                    excluded.last_generation),
+                updated_at=excluded.updated_at
+            """,
+            (memory_id, int(row[1] or 0) + 1, requested_at),
+        )
+        conn.execute(
+            """
+            INSERT INTO relation_frequency_changes(
+                memory_id, old_scope_id, new_scope_id, work_generation, requested_at
+            )
+            SELECT ?, ?, ?, last_generation, ?
+            FROM relation_frequency_generations WHERE memory_id=?
+            """,
+            (memory_id, str(row[2] or ""), str(row[3] or ""), requested_at, memory_id),
+        )
+        supersede_relation_frequency_failure(conn, memory_id, requested_at=requested_at)
+        recovered += 1
+    return recovered
+
+
 def _drain_change_rows(
     conn: sqlite3.Connection,
     limit: int,
@@ -212,7 +271,7 @@ def _drain_change_rows(
         savepoint = f"relation_frequency_{uuid.uuid4().hex}"
         conn.execute(f"SAVEPOINT {savepoint}")
         try:
-            sync_relation_frequency_memory(
+            sync_result = sync_relation_frequency_memory(
                 conn,
                 memory_id,
                 refresh_receipts=False,
@@ -241,6 +300,9 @@ def _drain_change_rows(
             )
             continue
         affected.update(scopes)
+        affected.update(
+            str(sync_result.get(key) or "") for key in ("old_scope_id", "new_scope_id")
+        )
         processed += 1
     for scope in sorted(scope for scope in affected if scope):
         refresh_relation_scope_frequency_receipt(conn, scope)
@@ -528,6 +590,12 @@ def drain_relation_frequency_work(
         else clock() + max(0.01, float(wall_clock_seconds))
     )
     try:
+        recovered = _requeue_orphaned_frequency_failures(
+            conn,
+            max(0, min(int(change_limit), 5000)),
+            deadline_monotonic=deadline,
+            clock=clock,
+        )
         changed = _drain_change_rows(
             conn,
             max(0, min(int(change_limit), 5000)),
@@ -611,6 +679,7 @@ def drain_relation_frequency_work(
             ).fetchone()[0]
         )
     return {
+        "requeued_orphan_failures": recovered,
         "changed_memories": changed,
         "focused_memories": focused,
         "backfilled_memories": backfilled,
@@ -638,6 +707,9 @@ def relation_frequency_debt_exists(conn: sqlite3.Connection) -> bool:
     if not _table_exists(conn, "relation_frequency_changes"):
         return False
     checks = [
+        "SELECT 1 FROM relation_frequency_failures f "
+        "WHERE NOT EXISTS (SELECT 1 FROM relation_frequency_changes c "
+        "WHERE c.memory_id=f.memory_id) LIMIT 1",
         "SELECT 1 FROM relation_frequency_changes c "
         "LEFT JOIN relation_frequency_failures f "
         "ON f.memory_id=c.memory_id AND f.work_generation=c.work_generation "

--- a/schemas.py
+++ b/schemas.py
@@ -403,22 +403,25 @@ SCOPE_RECALL_INSPECTOR_SCHEMA = {
 
 SCOPE_RECALL_MEMORY_SCHEMA = {
     "name": "scope_recall_memory",
-    "description": "Compact memory operations: inspect, feedback, update, merge, or forget by exact id.",
+    "description": "Memory operations by exact id. Candidate promote/archive: preview by default; dry_run=false applies the plan.",
     "parameters": {
         "type": "object",
         "properties": {
-            "action": {"type": "string", "enum": ["inspect", "feedback", "update", "merge", "forget"], "description": "Operation."},
-            "id": {"type": "string", "maxLength": MAX_MEMORY_ID_LENGTH, "description": "Memory id."},
+            "action": {"type": "string", "enum": ["inspect", "feedback", "update", "merge", "forget", "promote", "archive"]},
+            "dry_run": {"type": "boolean", "default": True},
+            "expected_updated_at": {"type": "string", "description": "Review revision; rejects stale plans."},
+            "expected_lifecycle": {"type": "string"},
+            "id": {"type": "string", "maxLength": MAX_MEMORY_ID_LENGTH},
             "ids": {
                 "type": "array",
                 "maxItems": MAX_MEMORY_IDS_PER_REQUEST,
                 "items": {"type": "string", "maxLength": MAX_MEMORY_ID_LENGTH},
                 "description": "Memory ids for forget.",
             },
-            "rating": {"type": "string", "description": "Feedback rating."},
-            "note": {"type": "string", "description": "Feedback note."},
+            "rating": {"type": "string"},
+            "note": {"type": "string"},
             "content": {"type": "string", "description": "Replacement or merged content."},
-            "target": {"type": "string", "enum": ["user", "memory", "project", "ops", "general"], "description": "Optional target."},
+            "target": {"type": "string", "enum": ["user", "memory", "project", "ops", "general"]},
             "target_id": {"type": "string", "maxLength": MAX_MEMORY_ID_LENGTH, "description": "Merge target id."},
             "source_ids": {
                 "type": "array",
@@ -429,7 +432,7 @@ SCOPE_RECALL_MEMORY_SCHEMA = {
             "source_candidate_id": {"type": "string", "description": "Optional merge audit candidate id."},
             "memory_type": {
                 "type": "string",
-                "description": "Optional semantic type for a structured update.",
+                "description": "Structured update semantic type.",
             },
             "claim": FACT_CLAIM_HINT_SCHEMA,
             "evolution": FACT_EVOLUTION_HINT_SCHEMA,

--- a/tests/test_adjudication_l4.py
+++ b/tests/test_adjudication_l4.py
@@ -67,6 +67,63 @@ def test_explicit_schema_valid_uncertain_is_semantic_uncertainty():
     assert parsed.error == ""
 
 
+@pytest.mark.parametrize("field,first,second", [
+    ("verdict", "unsupported", "supported"),
+    ("verdict", "supported", "unsupported"),
+    ("reason", "first", "second"),
+    ("schema_version", "old.v0", L4_SCHEMA_VERSION),
+])
+def test_duplicate_fields_cannot_override_an_l4_verdict(field, first, second):
+    fields = {"schema_version": L4_SCHEMA_VERSION, "verdict": "supported", "reason": "valid"}
+    fields[field] = second
+    raw = "{" + json.dumps(field) + ":" + json.dumps(first) + "," + json.dumps(fields)[1:]
+    parsed = parse_l4_response(raw)
+    assert not parsed.ok and parsed.error == "invalid_json"
+    assert parsed.verdict is None
+
+
+@pytest.mark.parametrize("length", [120, 121, 316, 4000])
+@pytest.mark.parametrize("verdict", ["supported", "unsupported", "uncertain"])
+def test_verbose_reason_preserves_valid_verdict_with_bounded_audit(length, verdict):
+    reason = "Evidence supports this claim. " + "additional detail " * length
+    reason = reason[:length]
+    parsed = parse_l4_response(json.dumps({
+        "schema_version": L4_SCHEMA_VERSION,
+        "verdict": verdict,
+        "reason": reason,
+    }))
+
+    assert parsed.ok
+    assert parsed.verdict == verdict
+    assert 0 < len(parsed.reason) <= 120
+    if length == 120:
+        assert parsed.reason == reason.strip()
+    else:
+        assert parsed.reason.startswith("Evidence supports this claim.")
+        assert parsed.reason.endswith("...")
+
+
+@pytest.mark.parametrize("reason", [None, 123, {}, [], "", " \n\t"])
+def test_reason_normalization_does_not_accept_invalid_reason_types(reason):
+    parsed = parse_l4_response(json.dumps({
+        "schema_version": L4_SCHEMA_VERSION,
+        "verdict": "supported",
+        "reason": reason,
+    }))
+    assert not parsed.ok
+    assert parsed.error == "invalid_reason"
+    assert parsed.verdict is None
+
+
+def test_review_prompt_exposes_reason_budget_and_complete_sentence_guidance():
+    request = build_review_request(
+        target="ops", memory_type="workflow", content="claim",
+        evidence_text="evidence", evidence_truncated=False,
+    )
+    assert "120 characters" in request.system_prompt
+    assert "complete sentence" in request.system_prompt
+
+
 def _evidence_conn() -> sqlite3.Connection:
     conn = sqlite3.connect(":memory:")
     conn.row_factory = sqlite3.Row

--- a/tests/test_candidate_review_tools.py
+++ b/tests/test_candidate_review_tools.py
@@ -1,0 +1,152 @@
+"""Online candidate review keeps the gateway writer, scope, and lifecycle authority."""
+
+import json
+
+import pytest
+
+from plugins.memory import load_memory_provider
+
+
+@pytest.fixture
+def provider(tmp_path):
+    config = tmp_path / "scope-recall" / "config.json"
+    config.parent.mkdir(parents=True)
+    config.write_text(json.dumps({"vector": {"enabled": False},
+                                  "relation_extraction_enabled": False}), encoding="utf-8")
+    plugin = load_memory_provider("scope-recall")
+    assert plugin is not None
+    plugin.initialize("online-review", hermes_home=str(tmp_path), platform="cli",
+                      user_id="review-user", chat_id="review-chat", agent_context="primary",
+                      agent_identity="reviewer", agent_workspace="hermes")
+    yield plugin
+    plugin.shutdown()
+
+
+def _candidate(provider):
+    memory_id, inserted, _ = provider._store_now(
+        content="The service uses blue green deployment with health validation.",
+        source="event-digest", target="memory", session_id="online-review",
+        metadata={"lifecycle": "candidate", "event_digest": True,
+                  "candidate_status": "needs_review"},
+    )
+    assert inserted
+    return memory_id
+
+
+def _call(provider, **args):
+    return json.loads(provider.handle_tool_call("scope_recall_memory", args))
+
+
+@pytest.mark.parametrize("action,lifecycle", [("promote", "promoted"), ("archive", "archived")])
+def test_candidate_review_plans_then_applies_inside_existing_writer(provider, action, lifecycle):
+    memory_id = _candidate(provider)
+    conn = provider._require_conn()
+    writer = provider._writer_thread
+    before = conn.execute("SELECT metadata FROM memories WHERE id=?", (memory_id,)).fetchone()[0]
+    planned = _call(provider, action=action, id=memory_id)
+    assert planned["ok"] and planned["dry_run"] and not planned["applied"]
+    assert conn.execute("SELECT metadata FROM memories WHERE id=?", (memory_id,)).fetchone()[0] == before
+
+    applied = _call(provider, action=action, id=memory_id, dry_run=False,
+                    expected_updated_at=planned["expected_updated_at"],
+                    expected_lifecycle=planned["expected_lifecycle"])
+    assert applied["ok"] and applied["applied"]
+    metadata = json.loads(conn.execute("SELECT metadata FROM memories WHERE id=?", (memory_id,)).fetchone()[0])
+    assert metadata["lifecycle"] == lifecycle
+    assert provider._truth_writer_role == "owner"
+    assert provider._writer_thread is writer and writer.is_alive()
+    assert not conn.in_transaction
+
+
+def test_candidate_review_honors_plan_revision(provider):
+    memory_id = _candidate(provider)
+    planned = _call(provider, action="promote", id=memory_id)
+    assert planned["ok"]
+    conn = provider._require_conn()
+    conn.execute("UPDATE memories SET updated_at='changed-after-plan' WHERE id=?", (memory_id,))
+    conn.commit()
+    result = _call(provider, action="promote", id=memory_id, dry_run=False,
+                   expected_updated_at=planned["expected_updated_at"])
+    assert not result["ok"] and result["status"] == "conflict"
+    assert json.loads(conn.execute("SELECT metadata FROM memories WHERE id=?", (memory_id,)).fetchone()[0])["lifecycle"] == "candidate"
+
+
+@pytest.mark.parametrize("dry_run", [True, False])
+def test_candidate_review_cannot_read_or_mutate_foreign_scope(provider, dry_run):
+    memory_id = _candidate(provider)
+    conn = provider._require_conn()
+    conn.execute("UPDATE memories SET scope_id='foreign-scope' WHERE id=?", (memory_id,))
+    conn.commit()
+    result = _call(provider, action="promote", id=memory_id, dry_run=dry_run)
+    assert not result["ok"] and result["status"] == "not_found"
+    assert "blue green" not in json.dumps(result)
+
+
+def test_store_receipt_reports_actual_candidate_lifecycle(provider):
+    stored = json.loads(provider.handle_tool_call("scope_recall_store", {
+        "content": "During migration we use a temporary database replica for verification.",
+        "target": "ops",
+    }))
+    assert stored["stored"]
+    row = provider._require_conn().execute("SELECT metadata FROM memories WHERE id=?", (stored["id"],)).fetchone()
+    lifecycle = json.loads(row[0])["lifecycle"]
+    assert lifecycle == "candidate"
+    assert stored["lifecycle"] == lifecycle
+    assert stored["receipt"]["lifecycle"] == lifecycle
+    assert stored["receipt"]["action"] != "promoted"
+
+
+@pytest.mark.parametrize("dry_run", [True, False])
+def test_online_review_cannot_mutate_fact_owned_projection(provider, dry_run):
+    memory_id = _candidate(provider)
+    conn = provider._require_conn()
+    conn.execute("""INSERT INTO fact_claims(
+        claim_id, memory_id, scope_id, subject_key, predicate_key, fact_key,
+        value, normalized_value, value_fingerprint, cardinality, recorded_at,
+        source_type, status)
+        SELECT 'fact-claim', id, scope_id, 'service', 'deployment', 'deployment',
+        'blue green', 'blue green', 'fingerprint', 'single', updated_at,
+        'manual', 'current' FROM memories WHERE id=?""", (memory_id,))
+    conn.commit()
+    result = _call(provider, action="archive", id=memory_id, dry_run=dry_run)
+    assert result["status"] == "invalid_state"
+    assert result["blocked_fact_ids"] == [memory_id]
+    assert json.loads(conn.execute("SELECT metadata FROM memories WHERE id=?", (memory_id,)).fetchone()[0])["lifecycle"] == "candidate"
+
+
+@pytest.mark.parametrize("lifecycle", ["promoted", "archived", "superseded", "active"])
+def test_online_review_does_not_reprocess_event_digest_rows(provider, lifecycle):
+    memory_id = _candidate(provider)
+    conn = provider._require_conn()
+    metadata = json.loads(conn.execute("SELECT metadata FROM memories WHERE id=?", (memory_id,)).fetchone()[0])
+    metadata["lifecycle"] = lifecycle
+    conn.execute("UPDATE memories SET metadata=? WHERE id=?", (json.dumps(metadata), memory_id))
+    conn.commit()
+    for dry_run in (True, False):
+        result = _call(provider, action="promote", id=memory_id, dry_run=dry_run)
+        assert result["status"] == "invalid_state" and not result["applied"]
+    assert json.loads(conn.execute("SELECT metadata FROM memories WHERE id=?", (memory_id,)).fetchone()[0]) == metadata
+
+
+def test_online_review_rolls_back_truth_when_audit_write_fails(provider):
+    memory_id = _candidate(provider)
+    conn = provider._require_conn()
+    before = tuple(conn.execute("SELECT metadata,updated_at FROM memories WHERE id=?", (memory_id,)).fetchone())
+    audit_count = conn.execute("SELECT COUNT(*) FROM governance_audit_events").fetchone()[0]
+    outbox_count = conn.execute("SELECT COUNT(*) FROM vector_outbox").fetchone()[0]
+    conn.execute("""CREATE TEMP TRIGGER reject_review_audit
+        BEFORE INSERT ON governance_audit_events
+        WHEN NEW.event_type = 'memory_candidate_review'
+        BEGIN SELECT RAISE(ABORT, 'injected audit failure'); END""")
+    conn.commit()
+    try:
+        result = _call(provider, action="archive", id=memory_id, dry_run=False)
+        assert result.get("error") and not result.get("applied")
+        assert tuple(conn.execute("SELECT metadata,updated_at FROM memories WHERE id=?", (memory_id,)).fetchone()) == before
+        assert conn.execute("SELECT COUNT(*) FROM governance_audit_events").fetchone()[0] == audit_count
+        assert conn.execute("SELECT COUNT(*) FROM vector_outbox").fetchone()[0] == outbox_count
+        assert not conn.in_transaction
+    finally:
+        conn.execute("DROP TRIGGER reject_review_audit")
+        conn.commit()
+    assert _call(provider, action="archive", id=memory_id, dry_run=False)["applied"]

--- a/tests/test_candidate_review_tools.py
+++ b/tests/test_candidate_review_tools.py
@@ -1,6 +1,9 @@
 """Online candidate review keeps the gateway writer, scope, and lifecycle authority."""
 
 import json
+import sqlite3
+import threading
+from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 
@@ -126,6 +129,55 @@ def test_online_review_does_not_reprocess_event_digest_rows(provider, lifecycle)
         result = _call(provider, action="promote", id=memory_id, dry_run=dry_run)
         assert result["status"] == "invalid_state" and not result["applied"]
     assert json.loads(conn.execute("SELECT metadata FROM memories WHERE id=?", (memory_id,)).fetchone()[0]) == metadata
+
+
+def test_concurrent_review_has_exactly_one_audited_transition(provider):
+    memory_id = _candidate(provider)
+    plan = _call(provider, action="promote", id=memory_id)
+    conn = provider._require_conn()
+    audit_count = conn.execute("SELECT COUNT(*) FROM governance_audit_events").fetchone()[0]
+    barrier = threading.Barrier(2)
+
+    def apply(action):
+        barrier.wait(timeout=10)
+        return _call(provider, action=action, id=memory_id, dry_run=False,
+                     expected_updated_at=plan["expected_updated_at"],
+                     expected_lifecycle=plan["expected_lifecycle"])
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        futures = [pool.submit(apply, action) for action in ("promote", "archive")]
+        results = [future.result(timeout=20) for future in futures]
+    assert sum(bool(result.get("applied")) for result in results) == 1
+    rejected = next(result for result in results if not result.get("applied"))
+    assert rejected["status"] in {"invalid_state", "conflict"}
+    assert conn.execute("SELECT COUNT(*) FROM governance_audit_events").fetchone()[0] == audit_count + 1
+    assert not conn.in_transaction
+    assert provider._truth_writer_role == "owner"
+
+
+def test_store_receipt_read_failure_preserves_committed_success(provider, monkeypatch, caplog):
+    private_error = "database is locked: private receipt diagnostic"
+
+    def unavailable(_memory_id):
+        raise sqlite3.OperationalError(private_error)
+
+    monkeypatch.setattr(provider._tool_service._port, "stored_memory_identity", unavailable)
+    conn = provider._require_conn()
+    before_count = conn.execute("SELECT COUNT(*) FROM memories").fetchone()[0]
+    result = json.loads(provider.handle_tool_call("scope_recall_store", {
+        "content": "Deployments retain a verified rollback image for service recovery.",
+        "target": "ops",
+    }))
+    assert conn.execute("SELECT COUNT(*) FROM memories").fetchone()[0] == before_count + 1
+    assert not conn.in_transaction
+    assert result.get("stored") is True
+    assert result["id"]
+    assert result["lifecycle"] == result["receipt"]["lifecycle"] == "unknown"
+    assert result["receipt"]["action"] == "unknown"
+    assert result["retry_count"] == 0
+    assert conn.execute("SELECT id FROM memories WHERE id=?", (result["id"],)).fetchone()
+    assert private_error not in json.dumps(result)
+    assert private_error not in caplog.text
 
 
 def test_online_review_rolls_back_truth_when_audit_write_fails(provider):

--- a/tests/test_direct_command_writer_admission.py
+++ b/tests/test_direct_command_writer_admission.py
@@ -29,6 +29,7 @@ from scope_recall._internal.application.memory_commands import (
     GovernMemoriesRequest,
     MergeMemoriesRequest,
     PrivacyPurgeRequest,
+    ReviewMemoryCandidateRequest,
 )
 from scope_recall._internal.runtime.command_adapter import ProviderCommandAdapter
 from scope_recall._internal.runtime.tool_port import ProviderToolRuntimeAdapter
@@ -545,6 +546,34 @@ def test_direct_command_read_only_modes_do_not_require_write_authority(
         "read_only": True
     }
     assert observed == ["govern", "dedupe", "fact_owned", "purge", "purge"]
+
+
+def test_candidate_apply_uses_existing_writer_and_capture_barrier(monkeypatch):
+    _assert_admitted_call(
+        monkeypatch, patch_target=memory_ops, patch_name="review_memory_candidate",
+        invoke=lambda adapter: adapter.review_candidate(ReviewMemoryCandidateRequest(
+            memory_id="candidate", action="promote", dry_run=False,
+        )), result={"applied": True}, capture_barrier=True,
+    )
+
+
+def test_candidate_plan_is_read_only_but_apply_requires_writer(monkeypatch):
+    adapter = ProviderCommandAdapter(_CommandHost(writer=False))
+    seen = []
+
+    def review(*args, **kwargs):
+        seen.append(kwargs["dry_run"])
+        return {"dry_run": True}
+
+    monkeypatch.setattr(memory_ops, "review_memory_candidate", review)
+    assert adapter.review_candidate(ReviewMemoryCandidateRequest(
+        memory_id="candidate", action="archive",
+    )) == {"dry_run": True}
+    with pytest.raises(RuntimeError, match=WRITE_AUTHORITY_BUSY):
+        adapter.review_candidate(ReviewMemoryCandidateRequest(
+            memory_id="candidate", action="archive", dry_run=False,
+        ))
+    assert seen == [True]
 
 
 def test_memory_mutation_service_rejects_fenced_unadmitted_mutation() -> None:

--- a/tests/test_endpoint_safety.py
+++ b/tests/test_endpoint_safety.py
@@ -63,6 +63,7 @@ class _RecordingHandler(BaseHTTPRequestHandler):
                 "path": self.path,
                 "authorization": self.headers.get("Authorization"),
                 "api_key": self.headers.get("x-api-key"),
+                "user_agent": self.headers.get("User-Agent"),
                 "body": body,
             }
         )
@@ -706,6 +707,20 @@ def test_chat_endpoint_builder_applies_policy_to_explicit_endpoint() -> None:
         )
         == "http://model.internal:1234/v1/chat/completions"
     )
+
+
+@pytest.mark.parametrize("header", [None, "ScopeRecallCustom/1.0"])
+def test_safe_http_transport_sends_identifiable_user_agent(header) -> None:
+    with _recording_server() as server:
+        request = urllib.request.Request(
+            _server_url(server, "/final"), data=b"{}",
+            headers={} if header is None else {"uSeR-aGeNt": header},
+            method="POST",
+        )
+        with safe_urlopen(request, timeout=5) as response:
+            response.read()
+    expected = header or "ScopeRecall/2.0 (+https://github.com/410979729/scope-recall-hermes)"
+    assert server.records[0]["user_agent"] == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/test_lance_process_store.py
+++ b/tests/test_lance_process_store.py
@@ -1,0 +1,299 @@
+"""Real subprocess crash, timeout, and vector round-trip regressions."""
+
+import importlib.util
+import gc
+import sqlite3
+import subprocess
+import sys
+import time
+import threading
+from types import SimpleNamespace
+import weakref
+
+import pytest
+
+import scope_recall.lance_process_store as process_store
+from scope_recall.vector_store import build_vector_store, VectorStoreCompatibilityError
+
+
+def _store(tmp_path):
+    return process_store.ProcessLanceVectorStore(tmp_path / "lancedb", table_name="memories", dimensions=3)
+
+
+@pytest.mark.parametrize("program", [
+    "import sys,os; sys.stdin.buffer.readline(); os._exit(17)",
+    "import sys; sys.stdin.buffer.readline(); print('invalid frame', flush=True)",
+])
+def test_native_worker_crash_does_not_exit_host_or_retry_mutation(tmp_path, monkeypatch, program):
+    monkeypatch.setattr(process_store, "_worker_command", lambda: [sys.executable, "-c", program])
+    store = _store(tmp_path)
+    with pytest.raises(RuntimeError, match="SQLite truth is intact"):
+        store.upsert_records([{"id": "pending"}])
+    assert store._process.poll() is not None
+    with pytest.raises(RuntimeError, match="closed"):
+        store.count_rows()
+    store.close()
+
+
+def test_worker_deadline_includes_blocked_pipe_write(tmp_path, monkeypatch):
+    monkeypatch.setattr(process_store, "_worker_command", lambda: [sys.executable, "-c", "import time; time.sleep(30)"])
+    store = _store(tmp_path)
+    store._request_timeout = 0.2
+    started = time.monotonic()
+    with pytest.raises(RuntimeError, match="outbox work remains pending"):
+        store.upsert_records([{"id": "pending", "content": "x" * 1000000}])
+    assert time.monotonic() - started < 10
+    assert store._process.poll() is not None
+    assert not store._reader.is_alive()
+    assert not store._sender.is_alive()
+
+
+def test_unreferenced_worker_is_reaped_without_host_shutdown(tmp_path, monkeypatch):
+    program = "import json,sys,time; r=json.loads(sys.stdin.buffer.readline()); print(json.dumps({'id':r['id'],'ok':True,'result':True}),flush=True); time.sleep(30)"
+    monkeypatch.setattr(process_store, "_worker_command", lambda: [sys.executable, "-c", program])
+    store = _store(tmp_path)
+    assert store.is_available()
+    worker = store._process
+    reader = store._reader
+    reference = weakref.ref(store)
+    del store
+    gc.collect()
+    reader.join(timeout=3)
+    assert reference() is None
+    assert worker.poll() is not None
+    assert not reader.is_alive()
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows venv redirector regression")
+def test_windows_venv_worker_pid_is_the_actual_interpreter(tmp_path, monkeypatch):
+    # On uv/CPython Windows venvs, sys.executable names a launcher that would
+    # otherwise create an unowned grandchild holding both anonymous pipes.
+    program = "import json,sys,os,time; r=json.loads(sys.stdin.buffer.readline()); print(json.dumps({'id':r['id'],'ok':True,'result':{'pid':os.getpid(),'prefix':sys.prefix}}),flush=True); time.sleep(30)"
+    monkeypatch.setattr(process_store, "_worker_command", lambda: [sys.executable, "-c", program])
+    store = _store(tmp_path)
+    try:
+        identity = store.list_records()
+        assert identity["pid"] == store._process.pid
+        assert identity["prefix"] == sys.prefix
+        started = time.monotonic()
+        store.close()
+        assert time.monotonic() - started < 5
+        assert store._process.poll() is not None
+        assert not store._reader.is_alive()
+        assert not store._sender.is_alive()
+    finally:
+        store.close()
+
+
+def _worker_script(setup):
+    root = process_store.Path(process_store.__file__).resolve().parent
+    return f"""
+import sys, types, os
+package = types.ModuleType('scope_recall')
+package.__path__ = [{str(root)!r}]
+sys.modules['scope_recall'] = package
+import scope_recall.vector_store as native
+from scope_recall._lance_worker import main
+{setup}
+main()
+"""
+
+
+def test_native_stdout_diagnostics_do_not_corrupt_protocol(tmp_path, monkeypatch):
+    script = _worker_script("""
+class NoisyStore:
+    def __init__(self, *args, **kwargs):
+        os.write(1, b'native initialization diagnostic\\n')
+    def is_available(self):
+        print('Python diagnostic', flush=True)
+        os.write(1, b'native operation diagnostic\\n')
+        return True
+    def close(self):
+        pass
+native.LanceVectorStore = NoisyStore
+""")
+    monkeypatch.setattr(process_store, "_worker_command", lambda: [sys.executable, "-c", script])
+    store = _store(tmp_path)
+    try:
+        assert store.is_available()
+    finally:
+        store.close()
+
+
+@pytest.mark.parametrize("failure", ["unavailable", "missing", "compatibility"])
+def test_runtime_failed_open_closes_private_worker(tmp_path, monkeypatch, failure):
+    import scope_recall.vector_runtime as runtime
+
+    closed = []
+
+    def open_existing():
+        if failure == "missing":
+            raise FileNotFoundError("missing physical storage")
+        raise VectorStoreCompatibilityError("wrong dimensions")
+
+    store = SimpleNamespace(
+        is_available=lambda: failure != "unavailable",
+        open_existing_for_update=open_existing,
+        close=lambda: closed.append(True),
+    )
+    monkeypatch.setattr(runtime, "build_vector_store", lambda *_args, **_kwargs: store)
+    monkeypatch.setattr(runtime, "native_vector_dependency_status", lambda: {"safe": False})
+    provider = SimpleNamespace(
+        _storage_dir=tmp_path, _vector_storage_dir=tmp_path,
+        _vector_config={}, _retrieval_config={}, _vector_backend="lancedb", _vector_store=None,
+    )
+    with pytest.raises((RuntimeError, FileNotFoundError)):
+        runtime._open_vector_store(provider, dimensions=3)
+    assert closed == [True]
+    assert provider._vector_store is None
+
+
+def test_windows_factory_does_not_import_native_libraries(tmp_path, monkeypatch):
+    import scope_recall.vector_store as native
+    monkeypatch.setattr(native.sys, "platform", "win32")
+    monkeypatch.setattr(native, "_optional_lancedb", lambda: pytest.fail("native import in host"))
+    store = build_vector_store("lancedb", storage_dir=tmp_path, table_name="memories", dimensions=3)
+    assert isinstance(store, process_store.ProcessLanceVectorStore)
+    assert store.backend == "lancedb" and store.dimensions == 3
+    assert store._process is None
+    store.close()
+
+
+def test_non_windows_python_process_options_preserve_default_launcher(monkeypatch):
+    import scope_recall.vector_store as native
+    monkeypatch.setattr(native.sys, "platform", "linux")
+    assert native._python_subprocess_options() == {}
+
+
+def test_embedding_module_does_not_eagerly_import_torch():
+    root = process_store.Path(process_store.__file__).resolve().parent
+    script = f"""
+import sys, types, builtins
+package = types.ModuleType('scope_recall')
+package.__path__ = [{str(root)!r}]
+sys.modules['scope_recall'] = package
+original = builtins.__import__
+def guarded(name, *args, **kwargs):
+    if name in ('sentence_transformers', 'torch'):
+        raise AssertionError('unexpected native model import')
+    return original(name, *args, **kwargs)
+builtins.__import__ = guarded
+import scope_recall.embedders
+assert 'torch' not in sys.modules
+"""
+    result = subprocess.run([sys.executable, "-c", script], capture_output=True, text=True, timeout=30)
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.skipif(importlib.util.find_spec("lancedb") is None, reason="optional LanceDB runtime missing")
+def test_real_native_worker_preserves_data_schema_scope_and_replay_idempotency(tmp_path):
+    store = _store(tmp_path)
+    assert store.is_available()
+    row = {"id": "one", "scope_id": "scope-a", "source": "test", "target": "memory",
+           "content": "durable fact", "summary": "fact", "updated_at": "2026-09-05",
+           "vector": [1.0, 0.0, 0.0]}
+    try:
+        store.open()
+        store.upsert_records([row])
+        store.upsert_records([row])
+        assert store.count_rows() == 1
+        assert store.search([1.0, 0.0, 0.0], scope_id="scope-a", limit=5)[0]["id"] == "one"
+        assert store.search([1.0, 0.0, 0.0], scope_id="foreign", limit=5) == []
+        assert store.list_ids() == ["one"]
+        assert store.list_records()["one"]["content"] == "durable fact"
+        assert store.audit_counts()["physical_rows"] == 1
+        with pytest.raises(VectorStoreCompatibilityError, match="shadow vector generation"):
+            store.repair_records({})
+        store.close()
+        store.open_existing_for_update()
+        assert store.count_rows() == 1
+        store.delete_by_ids(["one"])
+        assert store.count_rows() == 0
+    finally:
+        store.close()
+    assert store._process.poll() is not None
+
+
+@pytest.mark.skipif(importlib.util.find_spec("lancedb") is None, reason="optional LanceDB runtime missing")
+def test_native_crash_after_physical_commit_leaves_truth_and_retryable_outbox(tmp_path, monkeypatch):
+    from scope_recall.embedders import LocalHashEmbedder
+    from scope_recall.sql_store import ensure_schema, store_row
+    from scope_recall.vector_generation import GenerationIdentity, bootstrap_legacy_generation, enqueue_vector_event
+    import scope_recall.vector_runtime as runtime
+
+    conn = sqlite3.connect(tmp_path / "memory.sqlite3")
+    conn.row_factory = sqlite3.Row
+    ensure_schema(conn)
+    store_row(
+        conn, memory_id="pending", scope_id="scope-a", platform="test", user_id="user",
+        chat_id="", thread_id="", gateway_session_key="", agent_identity="test", agent_workspace="test",
+        session_id="test", source="test", target="memory", content="durable truth", metadata={},
+        allow_duplicate=True, enqueue_vector_intent=False,
+    )
+    manifest = bootstrap_legacy_generation(
+        conn, identity=GenerationIdentity(backend="lancedb", provider="local-hash", model="hash-v1", dimensions=16),
+    )
+    generation_id = str(manifest["generation_id"])
+    enqueue_vector_event(conn, event_key="test", generation_id=generation_id, memory_id="pending", operation="upsert")
+    conn.commit()
+
+    original_command = process_store._worker_command
+    script = _worker_script("""
+original_upsert = native.LanceVectorStore.upsert_records
+def crash_after_commit(self, rows):
+    original_upsert(self, rows)
+    os._exit(17)
+native.LanceVectorStore.upsert_records = crash_after_commit
+""")
+    monkeypatch.setattr(process_store, "_worker_command", lambda: [sys.executable, "-c", script])
+    store = process_store.ProcessLanceVectorStore(tmp_path / "lancedb", table_name="memories", dimensions=16)
+    provider = SimpleNamespace(
+        _storage_dir=tmp_path, _db_path=tmp_path / "memory.sqlite3",
+        _vector_generation_id=generation_id, _vector_store=store,
+        _embedder=LocalHashEmbedder(dimensions=16),
+        _vector_config={"enabled": True, "backend": "lancedb", "embedder": {
+            "provider": "local-hash", "model": "hash-v1", "dimensions": 16,
+        }},
+        _retrieval_config={"metric": "cosine"}, _vector_backend="lancedb",
+        _vector_ready=True, _vector_status="ready", _vector_enabled=True,
+        _scope_id="scope-a", _vector_text=lambda summary, content: content,
+        _lock=threading.RLock(), _vector_lock=threading.RLock(), _require_conn=lambda: conn,
+    )
+    try:
+        store.open()
+        assert runtime.replay_vector_outbox(provider, refresh_audit_after=True) == {"claimed": 1, "completed": 0, "failed": 1}
+        event = conn.execute("SELECT status, attempts FROM vector_outbox WHERE event_key = 'test'").fetchone()
+        assert tuple(event) == ("retry", 1)
+        assert conn.execute("SELECT content FROM memories WHERE id = 'pending'").fetchone()[0] == "durable truth"
+        # EOF can precede the process wait signal on Windows; fail-closed
+        # cleanup may terminate the already exiting worker with a new code.
+        assert store._process.poll() is not None
+        assert store.requires_reopen is True
+        assert provider._vector_ready is False
+        assert provider._vector_status == "needs_repair"
+        assert provider._vector_usable_for_query is False
+        assert provider._vector_reason_code == "native_worker_reopen_required"
+
+        conn.execute("UPDATE vector_outbox SET available_at = '2000-01-01T00:00:00+00:00'")
+        conn.commit()
+        for _attempt in range(3):
+            assert runtime.replay_vector_outbox(provider) == {"claimed": 0, "completed": 0, "failed": 0}
+        assert tuple(conn.execute("SELECT status, attempts FROM vector_outbox WHERE event_key = 'test'").fetchone()) == ("retry", 1)
+
+        # The online repair action delegates to setup_vector_layer. It opens
+        # the same generation and replays the already committed idempotent row.
+        monkeypatch.setattr(process_store, "_worker_command", original_command)
+        monkeypatch.setattr(runtime, "build_vector_store", lambda _backend, **kwargs: process_store.ProcessLanceVectorStore(
+            kwargs["storage_dir"] / "lancedb", table_name=kwargs["table_name"], dimensions=kwargs["dimensions"],
+        ))
+        runtime.setup_vector_layer(provider)
+        assert provider._vector_ready is True, provider._vector_message
+        assert provider._vector_status == "ready"
+        assert provider._vector_store.requires_reopen is False
+        assert provider._vector_store.count_rows() == 1
+        assert conn.execute("SELECT status FROM vector_outbox WHERE event_key = 'test'").fetchone()[0] == "completed"
+    finally:
+        store.close()
+        if provider._vector_store is not None:
+            provider._vector_store.close()
+        conn.close()

--- a/tests/test_lance_process_store.py
+++ b/tests/test_lance_process_store.py
@@ -8,6 +8,7 @@ import sys
 import time
 import threading
 from types import SimpleNamespace
+from concurrent.futures import ThreadPoolExecutor
 import weakref
 
 import pytest
@@ -297,3 +298,31 @@ native.LanceVectorStore.upsert_records = crash_after_commit
         if provider._vector_store is not None:
             provider._vector_store.close()
         conn.close()
+
+
+@pytest.mark.skipif(importlib.util.find_spec("lancedb") is None, reason="optional LanceDB runtime missing")
+def test_concurrent_native_calls_preserve_rows_scope_and_reopen(tmp_path):
+    store = _store(tmp_path)
+    rows = [{"id": f"parallel-{index}", "scope_id": f"scope-{index % 2}",
+             "source": "audit", "target": "memory", "content": f"Audited fact {index}",
+             "summary": "fact", "updated_at": "2026-09-05", "vector": [1.0, 0.0, 0.0]}
+            for index in range(12)]
+    try:
+        store.open()
+        with ThreadPoolExecutor(max_workers=4) as pool:
+            futures = [pool.submit(store.upsert, row) for row in rows]
+            for future in futures:
+                future.result(timeout=30)
+        assert set(store.list_ids()) == {row["id"] for row in rows}
+        for scope_id in ("scope-0", "scope-1"):
+            hits = store.search([1.0, 0.0, 0.0], scope_id=scope_id, limit=20)
+            assert {hit["id"] for hit in hits} == {row["id"] for row in rows if row["scope_id"] == scope_id}
+        assert store.search([1.0, 0.0, 0.0], scope_id="foreign-scope", limit=20) == []
+        with pytest.raises(VectorStoreCompatibilityError):
+            store.repair_records({})
+        assert store.count_rows() == len(rows)
+        store.close()
+        store.open_existing_for_update()
+        assert set(store.list_records()) == {row["id"] for row in rows}
+    finally:
+        store.close()

--- a/tests/test_optional_vector_deps.py
+++ b/tests/test_optional_vector_deps.py
@@ -236,6 +236,7 @@ def test_lancedb_availability_probe_does_not_import_unsafe_native_modules_in_pro
 
 def test_active_vector_generation_does_not_fallback_when_lancedb_probe_sigills(monkeypatch, tmp_path):
     import scope_recall.vector_store as vector_store
+    import scope_recall.vector_runtime as vector_runtime
     from scope_recall.vector_runtime import _open_vector_store
 
     class Result:
@@ -253,6 +254,9 @@ def test_active_vector_generation_does_not_fallback_when_lancedb_probe_sigills(m
 
     monkeypatch.setattr(vector_store, "_NATIVE_VECTOR_PROBE", None, raising=False)
     monkeypatch.setattr(vector_store, "subprocess", type("SubprocessStub", (), {"run": staticmethod(lambda *args, **kwargs: Result())}), raising=False)
+    monkeypatch.setattr(vector_runtime, "build_vector_store", lambda _backend, **kwargs: vector_store.LanceVectorStore(
+        Path(kwargs["storage_dir"]) / "lancedb", table_name=kwargs["table_name"], dimensions=kwargs["dimensions"]
+    ))
     provider = Provider()
 
     with pytest.raises(RuntimeError, match="returncode=132"):
@@ -265,6 +269,7 @@ def test_active_vector_generation_does_not_fallback_when_lancedb_probe_sigills(m
 
 def test_default_config_does_not_override_an_active_lancedb_generation_when_probe_sigills(monkeypatch, tmp_path):
     import scope_recall.vector_store as vector_store
+    import scope_recall.vector_runtime as vector_runtime
     from scope_recall.config import DEFAULT_CONFIG
     from scope_recall.vector_runtime import _open_vector_store
 
@@ -283,6 +288,9 @@ def test_default_config_does_not_override_an_active_lancedb_generation_when_prob
 
     monkeypatch.setattr(vector_store, "_NATIVE_VECTOR_PROBE", None, raising=False)
     monkeypatch.setattr(vector_store, "subprocess", type("SubprocessStub", (), {"run": staticmethod(lambda *args, **kwargs: Result())}), raising=False)
+    monkeypatch.setattr(vector_runtime, "build_vector_store", lambda _backend, **kwargs: vector_store.LanceVectorStore(
+        Path(kwargs["storage_dir"]) / "lancedb", table_name=kwargs["table_name"], dimensions=kwargs["dimensions"]
+    ))
     provider = Provider()
 
     with pytest.raises(RuntimeError, match="returncode=132"):

--- a/tests/test_provider_schemas.py
+++ b/tests/test_provider_schemas.py
@@ -77,10 +77,10 @@ def test_core_tool_schema_budget_and_digest_are_release_gated():
     assert result["ok"] is True, result
     assert result["measured"] == {
         "tool_count": 6,
-        "schema_chars": 9531,
-        "estimated_schema_tokens": 2383,
+        "schema_chars": 9588,
+        "estimated_schema_tokens": 2397,
         "canonical_schema_sha256": (
-            "7380485b5ee769b60383e7f6eabb836dd1637553bbbf17883bb6e564def8f5d6"
+            "d19b08d445c17c265ee216acfe06060714ac1848917d5e7d70aa0dc05edd615d"
         ),
     }
     assert CORE_TOOL_SCHEMA_POLICY["maximum_schema_chars"] == 9600

--- a/tests/test_relation_frequency_incremental.py
+++ b/tests/test_relation_frequency_incremental.py
@@ -14,6 +14,7 @@ import scope_recall.relation_frequency_maintenance as frequency_maintenance
 from scope_recall.relation_extraction import sync_extracted_relations_for_memory
 from scope_recall.relation_frequency_index import (
     ensure_relation_frequency_index_schema,
+    relation_frequency_snapshot,
     sync_relation_frequency_memory,
 )
 from scope_recall.sql_store import delete_rows, ensure_schema, store_row
@@ -70,6 +71,102 @@ def _visible_count(conn: sqlite3.Connection, scope_id: str) -> int:
         (scope_id,),
     ).fetchone()
     return int(row[0]) if row is not None else 0
+
+
+@pytest.mark.parametrize("operation", ["deleted", "moved"])
+def test_orphan_recovery_uses_current_truth_and_refreshes_both_scopes(operation):
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    ensure_schema(conn)
+    try:
+        _store(conn, memory_id="orphan", scope_id="scope-a", entity="Alpha Service",
+               timestamp="2026-08-30", commit=True)
+        if operation == "deleted":
+            conn.execute("DELETE FROM memories WHERE id='orphan'")
+        else:
+            conn.execute("UPDATE memories SET scope_id='scope-b', updated_at='2026-09-01' WHERE id='orphan'")
+        conn.execute("DELETE FROM relation_frequency_changes WHERE memory_id='orphan'")
+        conn.execute("DELETE FROM relation_focus_work")
+        conn.execute("""INSERT INTO relation_frequency_failures(
+            memory_id, old_scope_id, new_scope_id, work_generation,
+            attempts, status, last_error, last_failed_at)
+            VALUES('orphan','scope-a','scope-a',999,3,'dead_letter','stale failure','2026-08-30')""")
+        conn.commit()
+
+        first = frequency_maintenance.drain_relation_frequency_work(conn, wall_clock_seconds=5)
+        second = frequency_maintenance.drain_relation_frequency_work(conn, wall_clock_seconds=5)
+        assert first["requeued_orphan_failures"] == 1
+        assert second["requeued_orphan_failures"] == 0
+        assert _frequency(conn, "scope-a", "alpha service") == 0
+        assert _visible_count(conn, "scope-a") == 0
+        assert relation_frequency_snapshot(conn, "scope-a") is not None
+        assert conn.execute("SELECT COUNT(*) FROM relation_frequency_failures").fetchone()[0] == 0
+        assert conn.execute("SELECT last_generation FROM relation_frequency_generations WHERE memory_id='orphan'").fetchone()[0] > 999
+        if operation == "moved":
+            assert _frequency(conn, "scope-b", "alpha service") == 1
+            assert _visible_count(conn, "scope-b") == 1
+            assert relation_frequency_snapshot(conn, "scope-b") is not None
+        else:
+            assert conn.execute("SELECT COUNT(*) FROM relation_indexed_memories WHERE memory_id='orphan'").fetchone()[0] == 0
+    finally:
+        conn.close()
+
+
+def _orphan_frequency_failure(conn, memory_id="orphan", status="retry"):
+    conn.execute(
+        "INSERT INTO relation_frequency_failures(memory_id, old_scope_id, "
+        "new_scope_id, attempts, status, last_error, last_failed_at) "
+        "VALUES(?, 'scope-a', 'scope-a', 3, ?, 'OperationalError: database is locked', '2026-08-30')",
+        (memory_id, status),
+    )
+    conn.commit()
+
+
+@pytest.mark.parametrize("status", ["retry", "dead_letter"])
+def test_orphan_failure_rebuilds_current_truth_and_unblocks_scope(status):
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    ensure_schema(conn)
+    _store(conn, memory_id="orphan", scope_id="scope-a", entity="Alpha Service",
+           timestamp="2026-08-30", commit=True)
+    conn.execute("DELETE FROM relation_focus_work")
+    conn.commit()
+    _orphan_frequency_failure(conn, status=status)
+    assert relation_frequency_snapshot(conn, "scope-a") is None
+    assert frequency_maintenance.relation_frequency_debt_exists(conn)
+
+    result = frequency_maintenance.drain_relation_frequency_work(conn, wall_clock_seconds=5)
+
+    assert result["changed_memories"] == 1
+    assert conn.execute("SELECT COUNT(*) FROM relation_frequency_failures").fetchone()[0] == 0
+    assert relation_frequency_snapshot(conn, "scope-a") is not None
+    assert _frequency(conn, "scope-a", "alpha service") == 1
+    assert conn.execute(
+        "SELECT terminal_state FROM relation_work_dispositions "
+        "WHERE work_kind='frequency_change' AND work_key='orphan'"
+    ).fetchone()[0] == "superseded"
+    conn.close()
+
+
+def test_orphan_retry_becomes_bounded_durable_failure_if_rebuild_still_fails(monkeypatch):
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    ensure_schema(conn)
+    _store(conn, memory_id="orphan", scope_id="scope-a", entity="Alpha Service",
+           timestamp="2026-08-30", commit=True)
+    _orphan_frequency_failure(conn)
+
+    def fail_sync(*_args, **_kwargs):
+        raise ValueError("invalid companion")
+
+    monkeypatch.setattr(frequency_maintenance, "sync_relation_frequency_memory", fail_sync)
+    for _ in range(5):
+        frequency_maintenance.drain_relation_frequency_work(conn, wall_clock_seconds=5)
+    failure = conn.execute("SELECT attempts, status FROM relation_frequency_failures").fetchone()
+    assert tuple(failure) == (3, "dead_letter")
+    assert conn.execute("SELECT COUNT(*) FROM relation_frequency_changes").fetchone()[0] == 1
+    assert relation_frequency_snapshot(conn, "scope-a") is None
+    conn.close()
 
 
 def test_frequency_schema_ensure_does_not_rewrite_current_generation_receipts() -> None:

--- a/tests/test_release_blocker_regressions.py
+++ b/tests/test_release_blocker_regressions.py
@@ -628,10 +628,32 @@ class _VectorProvider:
         return f"{summary}\n{content}"
 
 
-def test_lancedb_fallback_registers_actual_sqlite_generation(tmp_path, monkeypatch):
+@pytest.fixture
+def lance_store_factory(monkeypatch):
+    """Inject dependency availability at the cross-platform factory boundary."""
+    import scope_recall.vector_bootstrap as vector_bootstrap
+    import scope_recall.vector_store as vector_store
+
+    original_factory = vector_store.build_vector_store
+
+    def factory(backend, **kwargs):
+        if backend == "lancedb":
+            return vector_store.LanceVectorStore(
+                Path(kwargs["storage_dir"]) / "lancedb",
+                table_name=kwargs["table_name"], dimensions=kwargs["dimensions"],
+                metric=kwargs.get("metric", "cosine"),
+            )
+        return original_factory(backend, **kwargs)
+
+    monkeypatch.setattr(vector_runtime, "build_vector_store", factory)
+    monkeypatch.setattr(vector_bootstrap, "build_vector_store", factory)
+    return vector_store.LanceVectorStore
+
+
+def test_lancedb_fallback_registers_actual_sqlite_generation(tmp_path, monkeypatch, lance_store_factory):
     conn = _conn(tmp_path / "memory.sqlite3")
     provider = _VectorProvider(conn, tmp_path)
-    monkeypatch.setattr(vector_runtime.LanceVectorStore, "is_available", lambda self: False)
+    monkeypatch.setattr(lance_store_factory, "is_available", lambda self: False)
 
     vector_runtime.setup_vector_layer(provider)
 
@@ -645,7 +667,7 @@ def test_lancedb_fallback_registers_actual_sqlite_generation(tmp_path, monkeypat
     provider._vector_store.close()
 
 
-def test_corrupt_truth_header_degrades_vector_startup(tmp_path, monkeypatch):
+def test_corrupt_truth_header_degrades_vector_startup(tmp_path, monkeypatch, lance_store_factory):
     """A failed live pager probe must keep the vector companion non-ready."""
 
     conn = _conn(tmp_path / "memory.sqlite3")
@@ -659,7 +681,7 @@ def test_corrupt_truth_header_degrades_vector_startup(tmp_path, monkeypatch):
             "error": "SQLite truth database probe failed",
         },
     )
-    monkeypatch.setattr(vector_runtime.LanceVectorStore, "is_available", lambda self: False)
+    monkeypatch.setattr(lance_store_factory, "is_available", lambda self: False)
 
     vector_runtime.setup_vector_layer(provider)
 
@@ -677,10 +699,11 @@ def test_active_sqlite_fallback_generation_reopens_without_implicit_backend_swit
     tmp_path,
     monkeypatch,
     lancedb_recovers,
+    lance_store_factory,
 ):
     conn = _conn(tmp_path / "memory.sqlite3")
     first = _VectorProvider(conn, tmp_path)
-    monkeypatch.setattr(vector_runtime.LanceVectorStore, "is_available", lambda self: False)
+    monkeypatch.setattr(lance_store_factory, "is_available", lambda self: False)
 
     vector_runtime.setup_vector_layer(first)
 
@@ -701,13 +724,13 @@ def test_active_sqlite_fallback_generation_reopens_without_implicit_backend_swit
     conn.commit()
 
     monkeypatch.setattr(
-        vector_runtime.LanceVectorStore,
+        lance_store_factory,
         "is_available",
         lambda self: lancedb_recovers,
     )
     if lancedb_recovers:
         monkeypatch.setattr(
-            vector_runtime.LanceVectorStore,
+            lance_store_factory,
             "open",
             lambda self: (_ for _ in ()).throw(AssertionError("active fallback must not switch backend implicitly")),
         )
@@ -751,11 +774,11 @@ def test_active_fallback_generation_requires_explicit_fallback_configuration(tmp
     assert not (tmp_path / "vector.sqlite3").exists()
 
 
-def test_existing_lancedb_manifest_rejects_sqlite_fallback(tmp_path, monkeypatch):
+def test_existing_lancedb_manifest_rejects_sqlite_fallback(tmp_path, monkeypatch, lance_store_factory):
     conn = _conn(tmp_path / "memory.sqlite3")
     _register_generation(conn, backend="lancedb")
     provider = _VectorProvider(conn, tmp_path)
-    monkeypatch.setattr(vector_runtime.LanceVectorStore, "is_available", lambda self: False)
+    monkeypatch.setattr(lance_store_factory, "is_available", lambda self: False)
 
     vector_runtime.setup_vector_layer(provider)
 

--- a/tests/test_vector_generation_safety.py
+++ b/tests/test_vector_generation_safety.py
@@ -458,7 +458,7 @@ def test_active_backend_failure_redacts_internal_stats_and_warning_surfaces(monk
         def _memory_isolated_for_scope():
             return False
 
-    monkeypatch.setattr(vector_runtime_module, "LanceVectorStore", UnavailableLanceStore)
+    monkeypatch.setattr(vector_runtime_module, "build_vector_store", UnavailableLanceStore)
     monkeypatch.setattr(
         vector_runtime_module,
         "native_vector_dependency_status",

--- a/tests/test_writer_idle_handoff.py
+++ b/tests/test_writer_idle_handoff.py
@@ -113,6 +113,30 @@ def _make_idle(*providers) -> None:
             provider._writer_handoff_last_truth_activity = observed
 
 
+def test_preflight_activity_veto_never_restarts_or_fences_healthy_writer(tmp_path, monkeypatch, caplog):
+    _write_config(tmp_path)
+    provider = _provider()
+    try:
+        _initialize(provider, tmp_path, "preflight-veto")
+        original_writer = provider._writer_thread
+
+        def unexpected_resume(_providers):
+            raise AssertionError("preflight never quiesced the writer")
+
+        monkeypatch.setattr(writer_handoff_module, "_abort_quiesced_handoff", unexpected_resume)
+        monkeypatch.setattr(writer_handoff_module, "_idle_veto", lambda *_a, **_k: "recent_truth_activity")
+        _perform_idle_handoff(provider, process_writer_handoff_state(tmp_path / "scope-recall"))
+
+        assert provider._truth_writer_role == "owner"
+        assert not provider._truth_writes_blocked()
+        assert provider._writer_thread is original_writer
+        assert original_writer.is_alive()
+        assert not writer_handoff_status(provider)["operator_action_required"]
+        assert "idle writer handoff did not complete" not in caplog.text
+    finally:
+        provider.shutdown()
+
+
 def _write_handoff_details(
     *,
     idle_seconds: float,

--- a/tool_profiles.py
+++ b/tool_profiles.py
@@ -28,10 +28,10 @@ CORE_TOOL_SCHEMA_POLICY = {
     "decision": "D-013",
     "profile": "core",
     "expected_tool_count": 6,
-    "expected_schema_chars": 9531,
+    "expected_schema_chars": 9588,
     "maximum_schema_chars": 9600,
     "maximum_estimated_schema_tokens": 2400,
-    "canonical_schema_sha256": "7380485b5ee769b60383e7f6eabb836dd1637553bbbf17883bb6e564def8f5d6",
+    "canonical_schema_sha256": "d19b08d445c17c265ee216acfe06060714ac1848917d5e7d70aa0dc05edd615d",
 }
 
 

--- a/tooling.py
+++ b/tooling.py
@@ -500,7 +500,15 @@ class ScopeRecallToolService:
             relation_sync_status = "completed"
         else:
             relation_sync_status = "not_run"
-        identity = self._port.stored_memory_identity(memory_id)
+        try:
+            identity = self._port.stored_memory_identity(memory_id)
+        except Exception as exc:
+            # The write has already committed. Receipt enrichment must not
+            # turn success into a retryable error or invent a lifecycle.
+            logger.warning(
+                "Scope Recall stored identity unavailable (%s)", type(exc).__name__
+            )
+            identity = {}
         lifecycle = str(identity.get("lifecycle") or "unknown")
         receipt_action = ("promoted" if lifecycle in {"active", "promoted"} else lifecycle) if inserted else outcome
         receipt = {

--- a/tooling.py
+++ b/tooling.py
@@ -503,15 +503,17 @@ class ScopeRecallToolService:
         identity = self._port.stored_memory_identity(memory_id)
         lifecycle = str(identity.get("lifecycle") or "unknown")
         receipt_action = ("promoted" if lifecycle in {"active", "promoted"} else lifecycle) if inserted else outcome
-        receipt = self._receipt(
-            receipt_action,
-            target=target,
-            id=memory_id,
-            scope_mode=scope_mode,
-        )
-        receipt["relation_sync_status"] = relation_sync_status
-        receipt.update(identity)
-        receipt["lifecycle"] = lifecycle
+        receipt = {
+            **self._receipt(
+                receipt_action,
+                target=target,
+                id=memory_id,
+                scope_mode=scope_mode,
+            ),
+            "relation_sync_status": relation_sync_status,
+            **identity,
+            "lifecycle": lifecycle,
+        }
         if recovered:
             receipt["recovered"] = True
             receipt["retry_count"] = retry_count

--- a/tooling.py
+++ b/tooling.py
@@ -123,7 +123,7 @@ class ScopeRecallToolService:
         }
     )
     _MEMORY_DISPATCH_WRITE_ACTIONS = frozenset(
-        {"feedback", "update", "merge", "forget"}
+        {"feedback", "update", "merge", "forget", "promote", "archive"}
     )
 
     def _truth_write_blocked_error(self, tool_name: str) -> str:
@@ -147,6 +147,8 @@ class ScopeRecallToolService:
                 "remove": "forget",
                 "get": "inspect",
             }
+            if action in {"promote", "archive"}:
+                return self._bool_arg(args, "dry_run", True)
             return aliases.get(action, action) == "inspect"
         if tool_name == "scope_recall_reflect":
             return not self._bool_arg(args or {}, "propose_memory", False)
@@ -175,6 +177,8 @@ class ScopeRecallToolService:
             return False
         action = str((args or {}).get("action") or "").strip().lower()
         action = action.replace("-", "_")
+        if action in {"promote", "archive"}:
+            return not self._bool_arg(args, "dry_run", True)
         return action in {"merge", "forget", "delete", "remove"}
 
     def handle(self, tool_name: str, args: dict[str, Any]) -> str:
@@ -496,13 +500,18 @@ class ScopeRecallToolService:
             relation_sync_status = "completed"
         else:
             relation_sync_status = "not_run"
+        identity = self._port.stored_memory_identity(memory_id)
+        lifecycle = str(identity.get("lifecycle") or "unknown")
+        receipt_action = ("promoted" if lifecycle in {"active", "promoted"} else lifecycle) if inserted else outcome
         receipt = self._receipt(
-            "promoted" if inserted else outcome,
+            receipt_action,
             target=target,
             id=memory_id,
             scope_mode=scope_mode,
         )
         receipt["relation_sync_status"] = relation_sync_status
+        receipt.update(identity)
+        receipt["lifecycle"] = lifecycle
         if recovered:
             receipt["recovered"] = True
             receipt["retry_count"] = retry_count
@@ -518,6 +527,8 @@ class ScopeRecallToolService:
                 "relation_sync_status": relation_sync_status,
                 "recovered": recovered,
                 "retry_count": retry_count,
+                **identity,
+                "lifecycle": lifecycle,
                 "receipt": receipt,
             }
         )
@@ -703,8 +714,18 @@ class ScopeRecallToolService:
             return self._handle_merge(args)
         if action == "forget":
             return self._handle_forget(args)
+        if action in {"promote", "archive"}:
+            memory_id = str(args.get("id") or "").strip()
+            if not memory_id:
+                return tool_error("id is required for candidate review")
+            return self._json(self._port.review_candidate(
+                memory_id=memory_id, action=action,
+                dry_run=self._bool_arg(args, "dry_run", True),
+                expected_updated_at=str(args.get("expected_updated_at") or ""),
+                expected_lifecycle=str(args.get("expected_lifecycle") or ""),
+            ))
         return tool_error(
-            "action must be one of: inspect, feedback, update, merge, forget"
+            "action must be one of: inspect, feedback, update, merge, forget, promote, archive"
         )
 
     def _handle_entity(self, args: dict[str, Any]) -> str:

--- a/vector_runtime.py
+++ b/vector_runtime.py
@@ -51,8 +51,6 @@ from .truth_connection import probe_truth_database_connection
 from .sqlite_recovery import is_sqlite_lock_contention, rollback_if_active
 from .sqlite_params import chunked_sql_parameters
 from .vector_store import (
-    LanceVectorStore,
-    VectorStoreCompatibilityError,
     build_vector_store,
     native_vector_dependency_status,
     normalize_vector_backend,
@@ -703,17 +701,18 @@ def _open_vector_store(provider: Any, *, dimensions: int) -> None:
     if backend != "lancedb":
         raise RuntimeError(f"unsupported backend {backend}")
 
-    vector_dir = storage_root / "lancedb"
-    temp_store = LanceVectorStore(
-        vector_dir, table_name=table_name, dimensions=dimensions, metric=metric
+    temp_store = build_vector_store(
+        "lancedb", storage_dir=storage_root, table_name=table_name, dimensions=dimensions, metric=metric
     )
-    if not temp_store.is_available():
-        status = native_vector_dependency_status()
-        detail = _native_dependency_detail(status)
-        raise RuntimeError(f"lancedb/pyarrow is not installed or unsafe ({detail})")
     try:
+        if not temp_store.is_available():
+            status = native_vector_dependency_status()
+            detail = _native_dependency_detail(status)
+            raise RuntimeError(f"lancedb/pyarrow is not installed or unsafe ({detail})")
         temp_store.open_existing_for_update()
-    except VectorStoreCompatibilityError:
+    except BaseException:
+        # Availability and ordinary open errors also leave a live native
+        # helper behind. Release it before propagating any failed startup.
         temp_store.close()
         raise
     bind_provider_vector_runtime(provider).vector_backend = "lancedb"
@@ -1934,9 +1933,31 @@ def _replay_vector_outbox_guarded(
     ):
         return {"claimed": 0, "completed": 0, "failed": 0}
 
+    store = bind_provider_vector_runtime(provider).vector_store
+
+    def require_native_reopen(error: str) -> bool:
+        if getattr(store, "requires_reopen", False) is not True:
+            return False
+        mark_vector_needs_repair(
+            provider, error, reason_code="native_worker_reopen_required",
+        )
+        return True
+
+    # A transport failure already consumed one real attempt. Claiming again
+    # against the same dead helper cannot succeed and would turn recoverable
+    # outbox work into dead letters before an operator can reopen the runtime.
+    if require_native_reopen("native vector worker stopped; run repair_vector or restart to reopen it"):
+        _refresh_vector_debt_counts(provider)
+        return {"claimed": 0, "completed": 0, "failed": 0}
+
     def on_failure(error: str) -> None:
-        _mark_vector_replay_degraded(provider, error)
+        if not require_native_reopen(error):
+            _mark_vector_replay_degraded(provider, error)
         logger.warning("Scope Recall vector replay failed: %s", error)
+
+    def audit_live_store() -> None:
+        if getattr(store, "requires_reopen", False) is not True:
+            refresh_vector_audit(provider)
 
     result = replay_committed_vector_events(
         bind_provider_vector_runtime(provider).require_conn(),
@@ -1960,7 +1981,7 @@ def _replay_vector_outbox_guarded(
         event_ids=event_ids,
         on_failure=on_failure,
         after_replay=(
-            (lambda: refresh_vector_audit(provider)) if refresh_audit_after else None
+            audit_live_store if refresh_audit_after else None
         ),
         on_physical_mutation=(
             lambda operation, memory_id, existed: _apply_incremental_vector_counts(

--- a/vector_store.py
+++ b/vector_store.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import importlib
 import inspect
 import logging
+import os
 import subprocess
 import sys
 from collections import Counter
@@ -245,6 +246,25 @@ def _trim_probe_output(value: str, *, limit: int = 500) -> str:
     return text[: limit - 3] + "..."
 
 
+def _python_subprocess_options() -> dict[str, Any]:
+    """Keep Windows venv identity without launching its redirector process.
+
+    Windows venv executables (including uv's) may create a second Python
+    process. Terminating the outer redirector does not kill that interpreter,
+    which can keep anonymous pipes open forever during timeout cleanup.
+    CPython's launcher environment preserves the venv with the base executable.
+    """
+    if sys.platform != "win32":
+        return {}
+    env = dict(os.environ)
+    env["__PYVENV_LAUNCHER__"] = sys.executable
+    return {
+        "executable": getattr(sys, "_base_executable", None) or sys.executable,
+        "env": env,
+        "creationflags": getattr(subprocess, "CREATE_NO_WINDOW", 0),
+    }
+
+
 def _probe_native_vector_dependencies() -> dict[str, Any]:
     """Probe LanceDB/PyArrow in a child process before importing in-process.
 
@@ -266,6 +286,7 @@ def _probe_native_vector_dependencies() -> dict[str, Any]:
             capture_output=True,
             timeout=_NATIVE_VECTOR_PROBE_TIMEOUT,
             check=False,
+            **_python_subprocess_options(),
         )
         status = {
             "safe": result.returncode == 0,
@@ -961,6 +982,10 @@ def build_vector_store(
         return SQLiteBruteForceVectorStore(db_path, table_name=table_name, dimensions=dimensions, metric=metric)
     if normalized == "lancedb":
         vector_dir = Path(storage_dir) / "lancedb"
+        if sys.platform == "win32":
+            from .lance_process_store import ProcessLanceVectorStore
+
+            return ProcessLanceVectorStore(vector_dir, table_name=table_name, dimensions=dimensions, metric=metric)
         return LanceVectorStore(vector_dir, table_name=table_name, dimensions=dimensions, metric=metric)
     if normalized == "pgvector":
         from .pgvector_store import PGVectorStore


### PR DESCRIPTION
Fix five reported runtime failures while retaining SQLite truth, writer ownership, and the existing six-tool budget.

- #65: preserve valid L4 verdicts with overlong reasons; reject ambiguous duplicate JSON fields.
- #66: reconstruct orphan relation-frequency work from current truth with bounded retries, refresh affected scopes, and avoid resuming a writer after a preflight-only veto.
- #67: supply an identifiable User-Agent at the shared safe HTTP boundary while preserving explicit provider headers.
- #68: review candidates through the running gateway writer with dry-run defaults, scope/Fact checks, revision comparison, and atomic lifecycle/audit/outbox writes. Return the actual stored lifecycle; if a post-commit receipt read fails, retain the successful result and committed id with lifecycle unknown, without retrying the write or logging raw exception content.
- #69: isolate Windows LanceDB runtime in a private persistent process, contain native exits/timeouts, preserve outbox retry budgets, isolate native stdout, and avoid uv launcher grandchildren during cleanup.

Validation for the follow-up audit commit `8f01c4c`: 30 focused tests and 367 protocol/transaction/scope/recovery/migration tests passed against latest official Hermes `79445a49`; Ruff passed and Pyright reported zero errors. Added real concurrent candidate-review and native-vector call tests. The post-commit receipt fault was reproduced as a failing regression before the fix. All 12 CI checks passed for this exact head, including the required aggregate and release gate: Windows Python 3.11/3.12 each passed 4,179 tests with 11 skips; all five Linux/macOS full-suite configurations each passed 4,169 with 21 skips. Wheel/sdist installation, Doctor, benchmark and privacy gates also passed. [CI run](https://github.com/410979729/scope-recall-hermes/actions/runs/33939197775).

Additional audit boundaries: local Windows native Lance failed at 261/265-character data paths in both the existing in-process implementation and the private helper. The same two migration tests pass unchanged under a shorter storage root. Use short Lance paths on affected installations. Worker limits remain 64 MiB per frame / 60 seconds per request; very large bulk operations need future pagination/chunking. The reporter's exact desktop dump/native-wheel combination and Cloudflare policy were not reproduced; tests cover real Lance I/O, hard exits/timeouts, and actual local HTTP requests.

The core schema remains within six tools / 9,600 characters. No database migration or release publication is included; changes are recorded under Unreleased. Issue #41 is outside this change.

Each issue fix credits its reporter as a commit co-author: JohnYinl, 849506054, ycheng87, yzy806806, and gfpyc. GitHub has recognized all five account associations. Their reproduction and diagnosis roles are recorded in CONTRIBUTORS.md. See docs/reliability-audit.2026-09.md for repaired findings, remaining adapter/offline-tool debt, and validation limits.

Fixes #65
Fixes #66
Fixes #67
Fixes #68
Fixes #69
