### PR TITLE
fix: prevent SQLite metadata deadlocks during writer handoff

### DIFF
--- a/_internal/runtime/writer_handoff.py
+++ b/_internal/runtime/writer_handoff.py
@@ -25,7 +25,7 @@ from ...writer_lease import (
     publish_writer_handoff_telemetry,
     truth_writer_process_snapshot,
 )
-from .peer_recovery import live_providers_for_database
+from .peer_recovery import live_providers_for_database, try_acquire_nonblocking
 
 logger = logging.getLogger(__name__)
 
@@ -40,6 +40,7 @@ _CONTENT_FREE_FAILURE_CODES = frozenset(
         "background_lock_busy",
         "background_lock_missing",
         "busy_capture_submission_lock",
+        "busy_provider_lock",
         "busy_writer_handoff_activity_lock",
         "busy_writer_lifecycle_lock",
         "capture_processing",
@@ -156,14 +157,43 @@ def note_truth_activity(provider: Any) -> None:
     _publish_runtime_telemetry(provider, event_kind="truth_activity")
 
 
-def _connection_total_changes(provider: Any) -> int | None:
-    conn = getattr(provider, "_conn", None)
-    if conn is None:
+def _hold_provider_lock_nonblocking(provider: Any) -> Any | None:
+    """Acquire ``provider._lock`` without waiting.
+
+    Only the published provider lock serializes the live connection.  A
+    missing or busy lock means the caller must not touch SQLite getters,
+    and a dummy lock must not be invented to pretend otherwise.
+    """
+
+    lock = getattr(provider, "_lock", None)
+    if not callable(getattr(lock, "release", None)):
+        return None
+    if not try_acquire_nonblocking(lock):
+        return None
+    return lock
+
+
+def _connection_total_changes(provider: Any) -> tuple[Any, int] | None:
+    """Return ``(published connection, total_changes)``, or unknown.
+
+    The current ``_conn`` is resolved only after the provider lock is
+    held, then released in ``finally``.  Contention or a missing lock
+    must not touch SQLite at all.  Callers compare connection identity
+    with ``is`` as well as the count; a replacement is not a no-op.
+    """
+
+    lock = _hold_provider_lock_nonblocking(provider)
+    if lock is None:
         return None
     try:
-        return int(conn.total_changes)
+        conn = getattr(provider, "_conn", None)
+        if conn is None:
+            return None
+        return (conn, int(conn.total_changes))
     except Exception:
         return None
+    finally:
+        lock.release()
 
 
 def _thread_work_state(provider: Any) -> threading.local:
@@ -208,7 +238,11 @@ def active_truth_work(provider: Any, *, user_initiated: bool = False) -> Iterato
     """Fence one potential truth unit and record activity only when appropriate.
 
     The active counter is the handoff veto.  Background no-op probes do not
-    perpetually renew the idle clock; an actual SQLite change does.  Explicit
+    perpetually renew the idle clock when both ``total_changes`` samples are
+    reliable and unchanged.  An actual SQLite change, or a conservatively
+    unknown sample (busy or missing provider lock, closed or replaced
+    connection), renews the truth clock so a possible mutation cannot be
+    treated as a no-op that would release the writer lease early.  Explicit
     user work renews the user clock even when the operation is a safe no-op.
     """
 
@@ -245,7 +279,12 @@ def active_truth_work(provider: Any, *, user_initiated: bool = False) -> Iterato
                     - 1,
                 ),
             )
-        if before is not None and after is not None and after != before:
+        if (
+            before is None
+            or after is None
+            or before[0] is not after[0]
+            or before[1] != after[1]
+        ):
             note_truth_activity(provider)
 
 
@@ -315,15 +354,24 @@ def _idle_veto(provider: Any, *, now: float, writer_may_be_stopped: bool) -> str
     writer_alive = _thread_alive(getattr(provider, "_writer_thread", None))
     if not writer_may_be_stopped and not writer_alive:
         return "writer_unavailable"
-    conn = getattr(provider, "_conn", None)
-    if conn is None:
-        return "connection_missing"
-    try:
-        if bool(conn.in_transaction):
-            return "transaction_open"
-    except Exception:
+    lock = getattr(provider, "_lock", None)
+    release = getattr(lock, "release", None)
+    if not callable(getattr(lock, "acquire", None)) or not callable(release):
         return "transaction_unknown"
-    return ""
+    if not try_acquire_nonblocking(lock):
+        return "busy_provider_lock"
+    try:
+        conn = getattr(provider, "_conn", None)
+        if conn is None:
+            return "connection_missing"
+        try:
+            if bool(conn.in_transaction):
+                return "transaction_open"
+        except Exception:
+            return "transaction_unknown"
+        return ""
+    finally:
+        release()
 
 
 def writer_handoff_status(provider: Any) -> dict[str, Any]:
@@ -1059,6 +1107,7 @@ def _perform_idle_handoff(provider: Any, state: Any) -> None:
             "recent_user_activity", "recent_truth_activity", "truth_work_active",
             "foreground_busy", "capture_queue_pending", "capture_processing",
             "digest_active", "activity_generation_changed",
+            "busy_provider_lock",
         }
         log = logger.debug if benign_veto else logger.warning
         log(

--- a/tests/test_writer_handoff_sqlite_contention.py
+++ b/tests/test_writer_handoff_sqlite_contention.py
@@ -1,0 +1,426 @@
+"""Issue #71: nonblocking provider-lock serialization for SQLite getters."""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import scope_recall._internal.runtime.writer_handoff as writer_handoff_module
+from scope_recall._internal.runtime.writer_handoff import (
+    _CONTENT_FREE_FAILURE_CODES,
+    _connection_total_changes,
+    _content_free_failure_code,
+    _idle_veto,
+    active_truth_work,
+    initialize_writer_handoff_activity,
+    maybe_schedule_idle_writer_handoff,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_NONBLOCKING_BOUND_SECONDS = 0.5
+_SUBPROCESS_TIMEOUT_SECONDS = 8.0
+
+
+class _SqliteTouchTracker:
+    """Record SQLite metadata getter access without changing values."""
+
+    def __init__(self, inner: sqlite3.Connection) -> None:
+        self.inner = inner
+        self.touches: list[str] = []
+
+    @property
+    def total_changes(self) -> int:
+        self.touches.append("total_changes")
+        return int(self.inner.total_changes)
+
+    @property
+    def in_transaction(self) -> bool:
+        self.touches.append("in_transaction")
+        return bool(self.inner.in_transaction)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self.inner, name)
+
+
+class _AliveThread:
+    def is_alive(self) -> bool:
+        return True
+
+
+class _EmptyQueue:
+    def empty(self) -> bool:
+        return True
+
+
+def _idle_owner(
+    *,
+    conn: Any,
+    lock: Any | None,
+    storage_dir: Path | None = None,
+    now: float | None = None,
+) -> SimpleNamespace:
+    observed = time.monotonic() if now is None else float(now)
+    provider = SimpleNamespace(
+        _config={"writer_lease": {"idle_release_seconds": 30}},
+        _truth_writer_role="owner",
+        _shutdown_requested=threading.Event(),
+        _writer_handoff_activity_lock=threading.RLock(),
+        _writer_handoff_last_user_activity=observed - 60,
+        _writer_handoff_last_truth_activity=observed - 60,
+        _writer_handoff_activity_generation=0,
+        _writer_handoff_active_truth_work=0,
+        _writer_handoff_last_probe=0.0,
+        _writer_handoff_fenced=False,
+        _foreground_busy_count=0,
+        _write_queue=_EmptyQueue(),
+        _capture_queue_processing=0,
+        _journal_digest_thread=None,
+        _writer_thread=_AliveThread(),
+        _conn=conn,
+        _storage_dir=storage_dir,
+    )
+    if lock is not None:
+        provider._lock = lock
+    initialize_writer_handoff_activity(provider)
+    with provider._writer_handoff_activity_lock:
+        provider._writer_handoff_last_user_activity = observed - 60
+        provider._writer_handoff_last_truth_activity = observed - 60
+    return provider
+
+
+def _hold_lock(lock: threading.RLock) -> tuple[threading.Thread, threading.Event]:
+    held = threading.Event()
+    release = threading.Event()
+
+    def run() -> None:
+        with lock:
+            held.set()
+            release.wait(5.0)
+
+    thread = threading.Thread(target=run, name="provider-lock-holder")
+    thread.start()
+    assert held.wait(timeout=2.0)
+    return thread, release
+
+
+def test_contended_metadata_reads_do_not_touch_sqlite_or_block() -> None:
+    raw = sqlite3.connect(":memory:", check_same_thread=False)
+    tracker = _SqliteTouchTracker(raw)
+    lock = threading.RLock()
+    provider = _idle_owner(conn=tracker, lock=lock)
+    thread, release = _hold_lock(lock)
+    try:
+        started = time.monotonic()
+        changes = _connection_total_changes(provider)
+        veto = _idle_veto(provider, now=time.monotonic(), writer_may_be_stopped=False)
+        elapsed = time.monotonic() - started
+    finally:
+        release.set()
+        thread.join(timeout=2.0)
+        raw.close()
+
+    assert changes is None
+    assert veto == "busy_provider_lock"
+    assert tracker.touches == []
+    assert elapsed < _NONBLOCKING_BOUND_SECONDS
+
+
+def test_missing_provider_lock_does_not_invent_a_guard_or_touch_sqlite() -> None:
+    raw = sqlite3.connect(":memory:")
+    tracker = _SqliteTouchTracker(raw)
+    provider = _idle_owner(conn=tracker, lock=None)
+    try:
+        assert getattr(provider, "_lock", None) is None
+        started = time.monotonic()
+        changes = _connection_total_changes(provider)
+        veto = _idle_veto(provider, now=time.monotonic(), writer_may_be_stopped=False)
+        elapsed = time.monotonic() - started
+    finally:
+        raw.close()
+
+    assert changes is None
+    assert veto == "transaction_unknown"
+    assert tracker.touches == []
+    assert elapsed < _NONBLOCKING_BOUND_SECONDS
+
+
+def test_uncontended_and_reentrant_reads_use_the_published_connection() -> None:
+    raw = sqlite3.connect(":memory:")
+    tracker = _SqliteTouchTracker(raw)
+    lock = threading.RLock()
+    provider = _idle_owner(conn=tracker, lock=lock)
+    try:
+        assert _connection_total_changes(provider) == (tracker, 0)
+        assert _idle_veto(provider, now=time.monotonic(), writer_may_be_stopped=False) == ""
+        assert tracker.touches == ["total_changes", "in_transaction"]
+
+        tracker.touches.clear()
+        with lock:
+            raw.execute("BEGIN")
+            assert _connection_total_changes(provider) == (tracker, 0)
+            assert (
+                _idle_veto(provider, now=time.monotonic(), writer_may_be_stopped=False)
+                == "transaction_open"
+            )
+            raw.rollback()
+        assert tracker.touches == ["total_changes", "in_transaction"]
+    finally:
+        raw.close()
+
+
+def test_missing_or_closed_published_connection_is_unknown() -> None:
+    raw = sqlite3.connect(":memory:")
+    lock = threading.RLock()
+    provider = _idle_owner(conn=raw, lock=lock)
+    try:
+        raw.close()
+        assert _connection_total_changes(provider) is None
+        assert _idle_veto(
+            provider, now=time.monotonic(), writer_may_be_stopped=False
+        ) in {"transaction_unknown", "connection_missing"}
+
+        provider._conn = None
+        assert _connection_total_changes(provider) is None
+        assert (
+            _idle_veto(provider, now=time.monotonic(), writer_may_be_stopped=False)
+            == "connection_missing"
+        )
+    finally:
+        try:
+            raw.close()
+        except Exception:
+            pass
+
+
+def test_replaced_connection_is_resolved_only_after_lock() -> None:
+    stale = _SqliteTouchTracker(sqlite3.connect(":memory:"))
+    live = sqlite3.connect(":memory:")
+    live.execute("CREATE TABLE replaced_probe(value TEXT NOT NULL)")
+    live.execute("INSERT INTO replaced_probe(value) VALUES ('live')")
+    live.commit()
+    lock = threading.RLock()
+    provider = _idle_owner(conn=stale, lock=lock)
+    try:
+        with lock:
+            provider._conn = live
+            observed = _connection_total_changes(provider)
+        assert observed is not None
+        observed_conn, observed_changes = observed
+        assert observed_conn is live
+        assert observed_changes == int(live.total_changes)
+        assert observed_changes > 0
+        assert stale.touches == []
+    finally:
+        stale.inner.close()
+        live.close()
+
+
+def test_reliable_noop_preserves_truth_clock_and_write_refreshes_it() -> None:
+    raw = sqlite3.connect(":memory:")
+    raw.execute("CREATE TABLE truth_probe(value TEXT NOT NULL)")
+    raw.commit()
+    provider = _idle_owner(conn=raw, lock=threading.RLock())
+    old_clock = float(provider._writer_handoff_last_truth_activity)
+    old_generation = int(provider._writer_handoff_activity_generation)
+    try:
+        with active_truth_work(provider):
+            assert provider._writer_handoff_active_truth_work == 1
+        assert provider._writer_handoff_active_truth_work == 0
+        assert provider._writer_handoff_last_truth_activity == old_clock
+        assert provider._writer_handoff_activity_generation == old_generation
+
+        with active_truth_work(provider):
+            raw.execute("INSERT INTO truth_probe(value) VALUES ('written')")
+            raw.commit()
+        assert provider._writer_handoff_active_truth_work == 0
+        assert provider._writer_handoff_last_truth_activity > old_clock
+        assert provider._writer_handoff_activity_generation == old_generation + 1
+    finally:
+        raw.close()
+
+
+def test_replaced_equal_counters_do_not_prove_noop() -> None:
+    first = sqlite3.connect(":memory:")
+    second = sqlite3.connect(":memory:")
+    provider = _idle_owner(conn=first, lock=threading.RLock())
+    old_clock = float(provider._writer_handoff_last_truth_activity)
+    old_generation = int(provider._writer_handoff_activity_generation)
+    try:
+        assert first is not second
+        assert first.total_changes == 0
+        assert second.total_changes == 0
+        with active_truth_work(provider):
+            assert provider._writer_handoff_active_truth_work == 1
+            with provider._lock:
+                provider._conn = second
+            assert provider._lock.acquire(blocking=False)
+            provider._lock.release()
+        assert provider._writer_handoff_active_truth_work == 0
+        assert provider._writer_handoff_last_truth_activity > old_clock
+        assert provider._writer_handoff_activity_generation == old_generation + 1
+    finally:
+        first.close()
+        second.close()
+
+
+def test_unknown_samples_do_not_prove_noop() -> None:
+    raw = sqlite3.connect(":memory:", check_same_thread=False)
+    provider = _idle_owner(conn=raw, lock=threading.RLock())
+    old_clock = float(provider._writer_handoff_last_truth_activity)
+    old_generation = int(provider._writer_handoff_activity_generation)
+    thread, release = _hold_lock(provider._lock)
+    try:
+        with active_truth_work(provider):
+            assert provider._writer_handoff_active_truth_work == 1
+        assert provider._writer_handoff_active_truth_work == 0
+        assert provider._writer_handoff_last_truth_activity > old_clock
+        assert provider._writer_handoff_activity_generation == old_generation + 1
+    finally:
+        release.set()
+        thread.join(timeout=2.0)
+        raw.close()
+
+
+def test_nested_work_and_exception_keep_accounting_balanced() -> None:
+    raw = sqlite3.connect(":memory:")
+    provider = _idle_owner(conn=raw, lock=threading.RLock())
+    try:
+        with active_truth_work(provider):
+            assert provider._writer_handoff_active_truth_work == 1
+            with active_truth_work(provider):
+                assert provider._writer_handoff_active_truth_work == 2
+            assert provider._writer_handoff_active_truth_work == 1
+        assert provider._writer_handoff_active_truth_work == 0
+        assert int(getattr(provider._writer_handoff_thread_work, "depth", 0) or 0) == 0
+
+        try:
+            with active_truth_work(provider):
+                assert provider._writer_handoff_active_truth_work == 1
+                raise RuntimeError("injected_truth_work_failure")
+        except RuntimeError as exc:
+            assert str(exc) == "injected_truth_work_failure"
+        assert provider._writer_handoff_active_truth_work == 0
+        assert int(getattr(provider._writer_handoff_thread_work, "depth", 0) or 0) == 0
+    finally:
+        raw.close()
+
+
+def test_busy_provider_fail_closes_handoff_without_starting_worker(
+    tmp_path: Path, monkeypatch
+) -> None:
+    started: list[str] = []
+    monkeypatch.setattr(
+        writer_handoff_module,
+        "_handoff_thread_main",
+        lambda *_args, **_kwargs: started.append("handoff"),
+    )
+    raw = sqlite3.connect(":memory:", check_same_thread=False)
+    lock = threading.RLock()
+    provider = _idle_owner(conn=raw, lock=lock, storage_dir=tmp_path / "scope-recall")
+    thread, release = _hold_lock(lock)
+    try:
+        assert (
+            _idle_veto(provider, now=time.monotonic(), writer_may_be_stopped=False)
+            == "busy_provider_lock"
+        )
+        assert maybe_schedule_idle_writer_handoff(provider) is False
+        assert started == []
+        assert (
+            _content_free_failure_code(
+                RuntimeError("busy_provider_lock"), phase="preflight"
+            )
+            == "busy_provider_lock"
+        )
+        assert "busy_provider_lock" in _CONTENT_FREE_FAILURE_CODES
+    finally:
+        release.set()
+        thread.join(timeout=2.0)
+        raw.close()
+
+
+def test_sqlite_callback_subprocess_returns_unknown_without_hanging() -> None:
+    script = r"""
+import json, sqlite3, sys, threading, time, types
+repo = sys.argv[1]
+pkg = types.ModuleType("scope_recall")
+pkg.__path__ = [repo]
+sys.modules["scope_recall"] = pkg
+from scope_recall._internal.runtime.writer_handoff import (
+    _connection_total_changes,
+    _idle_veto,
+    initialize_writer_handoff_activity,
+)
+conn = sqlite3.connect(":memory:", check_same_thread=False)
+lock = threading.RLock()
+entered = threading.Event()
+release = threading.Event()
+now = time.monotonic()
+provider = types.SimpleNamespace(
+    _conn=conn,
+    _lock=lock,
+    _truth_writer_role="owner",
+    _config={"writer_lease": {"idle_release_seconds": 30}},
+    _shutdown_requested=threading.Event(),
+    _foreground_busy_count=0,
+    _write_queue=types.SimpleNamespace(empty=lambda: True),
+    _capture_queue_processing=0,
+    _journal_digest_thread=None,
+    _writer_thread=types.SimpleNamespace(is_alive=lambda: True),
+)
+initialize_writer_handoff_activity(provider)
+with provider._writer_handoff_activity_lock:
+    provider._writer_handoff_last_user_activity = now - 60
+    provider._writer_handoff_last_truth_activity = now - 60
+
+def sql_callback():
+    entered.set()
+    release.wait(2.0)
+    return 1
+
+conn.create_function("hold_mutex", 0, sql_callback)
+
+def query():
+    with lock:
+        conn.execute("select hold_mutex()").fetchall()
+
+thread = threading.Thread(target=query, daemon=True)
+thread.start()
+assert entered.wait(2.0)
+started = time.monotonic()
+try:
+    changes = _connection_total_changes(provider)
+    veto = _idle_veto(provider, now=time.monotonic(), writer_may_be_stopped=False)
+    elapsed = time.monotonic() - started
+    print(json.dumps({
+        "changes": changes,
+        "veto": veto,
+        "elapsed": elapsed,
+        "sqlite": sqlite3.sqlite_version,
+    }))
+finally:
+    release.set()
+    thread.join(2.0)
+    conn.close()
+"""
+    completed = subprocess.run(
+        [sys.executable, "-c", script, str(_REPO_ROOT)],
+        cwd=str(_REPO_ROOT),
+        capture_output=True,
+        text=True,
+        timeout=_SUBPROCESS_TIMEOUT_SECONDS,
+        env={**os.environ, "PYTHONDONTWRITEBYTECODE": "1"},
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stderr
+    payload = json.loads(completed.stdout.strip().splitlines()[-1])
+    assert payload["changes"] is None
+    assert payload["veto"] == "busy_provider_lock"
+    assert float(payload["elapsed"]) < _NONBLOCKING_BOUND_SECONDS

--- a/tests/test_writer_idle_handoff.py
+++ b/tests/test_writer_idle_handoff.py
@@ -1126,6 +1126,7 @@ def test_every_busy_surface_vetoes_idle_handoff(condition, expected):
         _capture_queue_processing=0,
         _journal_digest_thread=None,
         _writer_thread=_AliveThread(),
+        _lock=threading.RLock(),
         _conn=_VetoConnection(),
     )
     if condition == "foreground":


### PR DESCRIPTION
## Summary
Addresses #71.

- Serialize writer-handoff reads of SQLite `total_changes` and `in_transaction` with the existing Provider lock, acquired nonblocking. A busy or unavailable connection is unknown, not evidence that the writer is idle.
- Fail closed before handoff when the Provider lock is busy, without restarting a healthy writer or escalating ordinary contention to warning-level failures.
- Bind activity samples to the exact connection identity and change count. Connection replacement or an unknown sample conservatively refreshes truth activity; a known, unchanged connection remains a no-op. The Provider lock is never held across the work-unit body.

## Why this can freeze the entire process
SQLite 3.53.4 protects these metadata getters with its connection mutex. CPython calls them while holding the GIL. An unguarded getter can therefore wait for a SQLite mutex held by a query/callback that needs to reacquire the GIL. The previous writer-handoff sampling and idle-veto paths permitted that lock inversion.

## Verification
- Six behavioral regressions fail against the unchanged base source.
- Independent focused verification on Windows / Python 3.11.9: **102 passed** with SQLite 3.53.1, then **102 passed** with the official SQLite 3.53.4 DLL loaded only into disposable verification processes.
- Two real SQLite callback probes hang on the original production functions with SQLite 3.53.4 and are terminated by an external timeout. The exact probes return promptly with this patch: unknown activity sample / busy-provider veto.
- Same-connection no-op, actual write, equal-counter connection replacement, nested work, exception cleanup, writer admission, idle handoff and telemetry are covered. Ruff passes on all changed files.
- The delivered patch was applied to a clean base clone, matched against the reviewed source, and tested there. `git apply --check` also passes against PR #72 head `5944060abfd866fb9d2ea2176ee70a57bb259580`; this PR does not incorporate or depend on #72.

- Parent verification including the architecture-convergence tests: **118 passed**. Ruff passes on all PR-changed files and Pyright reports zero errors on the modified production module. The helper docstring uses descriptive wording because the existing frozen architecture metric scans source text, including docstrings; its thresholds and executable behavior remain unchanged.

## Boundaries
This fixes a reproduced lock inversion consistent with the reported stacks; confirmation that every historical gateway freeze is resolved still requires reporter-side observation. Local verification does not reproduce the reporter's full Linux/Python 3.13 environment. Cross-platform CI is tracked separately below.

No version bump, schema/config change, deployment, release, or live database operation.
